### PR TITLE
Setup - Add base CI configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - feature/add-project-ci # Temporary: to test the workflow itself
   pull_request:
     types:
       - opened
@@ -67,7 +66,7 @@ jobs:
           if [ -n "$GOOGLE_SERVICES" ]; then
             echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           else
-            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created. Should be present after B2"
+            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created."
           fi
 
       # Step 6: Ensure gradlew wrapper is executable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - feature/add-project-ci # Temporary: to test the workflow itself
   pull_request:
     types:
       - opened

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,7 @@ on:
 jobs:
   project-ci:
     name: CI-Project
-    runs-on:
-      group: runners_v1   # Uses the project’s runner group
+    runs-on: [ubuntu-latest]
 
     env:
       app_name: ProjectDebug

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,164 @@
+name: Project CI - Test Runner
+
+# Triggers:
+# - Runs on commits pushed to main
+# - Runs when a pull request is opened, synchronized (updated), or reopened
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  project-ci:
+    name: CI-Project
+    runs-on:
+      group: runners_v1   # Uses the project’s runner group
+
+    env:
+      app_name: ProjectDebug
+
+    defaults:
+      run:
+        working-directory: ./${{ env.base_folder }}
+
+    steps:
+      # Step 1: Checkout repository source code
+      # Fetches the repo including all submodules. Full history is required (fetch-depth: 0).
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      # Step 2: Clean Gradle cache
+      # Prevents issues caused by corrupted or stale Gradle state.
+      - name: Remove current gradle cache
+        run: rm -rf ~/.gradle
+
+      # Step 3: Setup JDK 17 (Temurin distribution)
+      # Required for building Android projects.
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      # Step 4: Restore Gradle dependency cache
+      # Saves time by reusing Gradle wrapper and dependency caches across builds.
+      - name: Retrieve gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      # Step 5: Ensure gradlew wrapper is executable
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # Step 6: Install NodeJS (version 22)
+      # Needed for Firebase CLI and Firestore emulator testing.
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Step 7: Install Firebase CLI globally
+      # Used to run emulators and test Firestore security rules.
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      # Step 8: Validate Firestore configuration and run Firestore rules tests (if present)
+      # - Ensures firebase.json exists and includes emulator config
+      # - Ensures Firestore rules are referenced correctly
+      # - Runs tests in firebase/firestore/test if available
+      - name: Firestore Security Rules tests
+        run: |
+          if [ ! -e "firebase.json" ]; then
+            echo "Warning: 'firebase.json' file is missing. Run 'firebase emulators:init'."
+            exit 0
+          fi
+          jq -e '.emulators' firebase.json >/dev/null || {
+            echo "Error: 'firebase.json' is missing 'emulators'. Run 'firebase emulators:init'."
+            exit 1
+          }
+          for e in auth firestore; do
+            jq -e ".emulators.$e" firebase.json >/dev/null || {
+              echo "Error: 'firebase.json' is missing 'emulators.$e'. Run 'firebase emulators:init'."
+              exit 1
+            }
+          done
+          if [ -e "firebase/firestore/firestore.rules" ]; then
+            jq -e '.firestore.rules' firebase.json >/dev/null || {
+              echo "Error: 'firebase.json' is missing 'firestore.rules'."
+              exit 1
+            }
+            (cd firebase/firestore/test 2>/dev/null && npm install && npm test) || exit $?
+          else
+            echo "Warning: Firestore rules file not found in firebase/firestore. Rules should be added for emulator testing."
+          fi
+
+      # Step 9: Run Kotlin formatting check
+      # Enforces style rules via ktfmt plugin.
+      - name: KTFmt Check
+        run: ./gradlew ktfmtCheck
+
+      # Step 10: Assemble the app and run static analysis
+      # - Builds a Debug APK
+      # - Runs Android lint checks
+      # - Uses parallel execution and build cache to speed up builds
+      - name: Assemble
+        run: ./gradlew assembleDebug lint --parallel --build-cache
+
+      # Step 11: Run unit tests and verification tasks
+      # Executes tests defined in the Gradle check task (includes unit tests, lint, etc.).
+      - name: Run tests
+        run: ./gradlew check --parallel --build-cache
+
+      # Step 12: Start Firebase emulators (Auth + Firestore)
+      # Runs in the background to support instrumentation tests.
+      - name: Start Firebase emulators
+        run: |
+          if [ -e "firebase.json" ] && jq -e '.emulators' firebase.json >/dev/null; then
+            echo "Starting Firebase emulators for instrumentation tests..."
+            firebase emulators:start --only auth,firestore --project demo-project &
+            echo "Firebase emulators started"
+          else
+            echo "Firebase emulators not configured, skipping emulator startup..."
+          fi
+
+      # Step 13: Run instrumentation tests on an Android emulator
+      # - Spins up an Android emulator (API 34, x86_64, Google APIs)
+      # - Disables UI (no-window) and animations for faster CI execution
+      # - Runs connectedCheck (integration/instrumentation tests)
+      - name: Run instrumentation tests
+        timeout-minutes: 25
+        uses: RandyLutcavich/android-emulator-runner-without-sdk-setup@v1.0.3
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          avd-name: github
+          force-avd-creation: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
+          disable-animations: true
+          script: ./gradlew connectedCheck --parallel --build-cache
+
+      # Step 14: Generate code coverage report
+      # Uses Jacoco to collect test coverage metrics.
+      - name: Generate coverage
+        run: ./gradlew jacocoTestReport
+
+      # Step 15: Upload coverage report as an artifact
+      # Stores results in GitHub Actions for later download/inspection.
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: Coverage report
+          path: app/build/reports/jacoco/jacocoTestReport

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,10 +17,11 @@ on:
 jobs:
   project-ci:
     name: CI-Project
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest  # Fixed: removed array brackets
 
     env:
       app_name: ProjectDebug
+      base_folder: .  # Fixed: added missing base_folder environment variable
 
     defaults:
       run:
@@ -30,7 +31,7 @@ jobs:
       # Step 1: Checkout repository source code
       # Fetches the repo including all submodules. Full history is required (fetch-depth: 0).
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4  # Updated from v3 to v4 for ubuntu-24.04 compatibility
         with:
           submodules: recursive
           fetch-depth: 0
@@ -43,7 +44,7 @@ jobs:
       # Step 3: Setup JDK 17 (Temurin distribution)
       # Required for building Android projects.
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4  # Updated from v3 to v4 for ubuntu-24.04 compatibility
         with:
           distribution: "temurin"
           java-version: "17"
@@ -51,7 +52,7 @@ jobs:
       # Step 4: Restore Gradle dependency cache
       # Saves time by reusing Gradle wrapper and dependency caches across builds.
       - name: Retrieve gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4  # Updated from v3 to v4
         with:
           path: |
             ~/.gradle/caches
@@ -133,13 +134,22 @@ jobs:
             echo "Firebase emulators not configured, skipping emulator startup..."
           fi
 
-      # Step 13: Run instrumentation tests on an Android emulator
+      # Step 13: Enable KVM for hardware acceleration
+      # Required for Android emulator to run efficiently on Linux
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Step 14: Run instrumentation tests on an Android emulator
+      # - Uses ReactiveCircus runner which handles SDK setup automatically
       # - Spins up an Android emulator (API 34, x86_64, Google APIs)
       # - Disables UI (no-window) and animations for faster CI execution
       # - Runs connectedCheck (integration/instrumentation tests)
       - name: Run instrumentation tests
         timeout-minutes: 25
-        uses: RandyLutcavich/android-emulator-runner-without-sdk-setup@v1.0.3
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
           target: google_apis
@@ -150,12 +160,12 @@ jobs:
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
 
-      # Step 14: Generate code coverage report
+      # Step 15: Generate code coverage report
       # Uses Jacoco to collect test coverage metrics.
       - name: Generate coverage
         run: ./gradlew jacocoTestReport
 
-      # Step 15: Upload coverage report as an artifact
+      # Step 16: Upload coverage report as an artifact
       # Stores results in GitHub Actions for later download/inspection.
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,23 +59,34 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-      # Step 5: Ensure gradlew wrapper is executable
+      # Step 5: Load google-services.json and local.properties from the secrets
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created. Should be present after B2"
+          fi
+
+      # Step 6: Ensure gradlew wrapper is executable
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      # Step 6: Install NodeJS (version 22)
+      # Step 7: Install NodeJS (version 22)
       # Needed for Firebase CLI and Firestore emulator testing.
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      # Step 7: Install Firebase CLI globally
+      # Step 8: Install Firebase CLI globally
       # Used to run emulators and test Firestore security rules.
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      # Step 8: Validate Firestore configuration and run Firestore rules tests (if present)
+      # Step 9: Validate Firestore configuration and run Firestore rules tests (if present)
       # - Ensures firebase.json exists and includes emulator config
       # - Ensures Firestore rules are referenced correctly
       # - Runs tests in firebase/firestore/test if available
@@ -105,24 +116,24 @@ jobs:
             echo "Warning: Firestore rules file not found in firebase/firestore. Rules should be added for emulator testing."
           fi
 
-      # Step 9: Run Kotlin formatting check
+      # Step 10: Run Kotlin formatting check
       # Enforces style rules via ktfmt plugin.
       - name: KTFmt Check
         run: ./gradlew ktfmtCheck
 
-      # Step 10: Assemble the app and run static analysis
+      # Step 11: Assemble the app and run static analysis
       # - Builds a Debug APK
       # - Runs Android lint checks
       # - Uses parallel execution and build cache to speed up builds
       - name: Assemble
         run: ./gradlew assembleDebug lint --parallel --build-cache
 
-      # Step 11: Run unit tests and verification tasks
+      # Step 12: Run unit tests and verification tasks
       # Executes tests defined in the Gradle check task (includes unit tests, lint, etc.).
       - name: Run tests
         run: ./gradlew check --parallel --build-cache
 
-      # Step 12: Start Firebase emulators (Auth + Firestore)
+      # Step 13: Start Firebase emulators (Auth + Firestore)
       # Runs in the background to support instrumentation tests.
       - name: Start Firebase emulators
         run: |
@@ -134,7 +145,7 @@ jobs:
             echo "Firebase emulators not configured, skipping emulator startup..."
           fi
 
-      # Step 13: Enable KVM for hardware acceleration
+      # Step 14: Enable KVM for hardware acceleration
       # Required for Android emulator to run efficiently on Linux
       - name: Enable KVM group perms
         run: |
@@ -142,7 +153,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Step 14: Run instrumentation tests on an Android emulator
+      # Step 15: Run instrumentation tests on an Android emulator
       # - Uses ReactiveCircus runner which handles SDK setup automatically
       # - Spins up an Android emulator (API 34, x86_64, Google APIs)
       # - Disables UI (no-window) and animations for faster CI execution
@@ -160,12 +171,12 @@ jobs:
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
 
-      # Step 15: Generate code coverage report
+      # Step 16: Generate code coverage report
       # Uses Jacoco to collect test coverage metrics.
       - name: Generate coverage
         run: ./gradlew jacocoTestReport
 
-      # Step 16: Upload coverage report as an artifact
+      # Step 17: Upload coverage report as an artifact
       # Stores results in GitHub Actions for later download/inspection.
       - name: Upload coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds a base CI workflow from SwEnt with the following:

* Runs on `main` push and PR events (opened, synchronized, reopened).
* Checks out repo with submodules and full history.
* Cleans Gradle cache and restores dependencies.
* Sets up JDK 17, NodeJS 22, and Firebase CLI.
* Decodes secrets for `google-services.json`.
* Validates Firestore emulator config and runs rules tests.
* Checks Kotlin formatting (ktfmt).
* Builds Debug APK, runs lint and unit tests (`assembleDebug`, `check`).
* Starts Firebase emulators for instrumentation tests.
* Enables KVM for emulator hardware acceleration.
* Runs instrumentation tests on API 34 Android emulator.
* Generates and uploads Jacoco code coverage reports.

All steps are optimized for CI speed, cache reuse, and compatibility with Ubuntu 24.04.