### PR TITLE
Bugfix/fix: migrate SonarCloud analysis to GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,15 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
-      # Step 4: Restore Gradle dependency cache
+      # Step 4: Restore Gradle and SonarQube dependency cache
       # Saves time by reusing Gradle wrapper and dependency caches across builds.
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Retrieve gradle cache
         uses: actions/cache@v4  # Updated from v3 to v4
         with:
@@ -191,5 +198,5 @@ jobs:
       - name: SonarCloud analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar -Dsonar.token=$SONAR_TOKEN
+        run: ./gradlew sonar --info
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-      # Step 5: Load google-services.json and local.properties from the secrets
+      # Step 5: Load google-services.json from the secrets
       - name: Decode secrets
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
@@ -185,3 +185,11 @@ jobs:
         with:
           name: Coverage report
           path: app/build/reports/jacoco/jacocoTestReport
+
+      # Step 18: Run SonarCloud analysis
+      # Analyzes code quality and uploads test coverage to SonarCloud
+      - name: SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar -Dsonar.token=$SONAR_TOKEN
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.debug
+import org.gradle.kotlin.dsl.release
 import java.io.FileInputStream
 import java.util.Properties
 plugins {
@@ -32,9 +34,11 @@ android {
     }
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true  // Enable obfuscation
+            isShrinkResources = true // Removes unused resources (colors, strings, etc.)
             proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
         }
         debug {
@@ -42,6 +46,7 @@ android {
             enableAndroidTestCoverage = true
         }
     }
+
     testCoverage {
         jacocoVersion = "0.8.11"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,9 +101,9 @@ jacoco {
 }
 sonar {
     properties {
-        property("sonar.projectKey", "your_project_key")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "your_organization")
+        property("sonar.projectKey", "CampusReachEight_CampusReach_team_08")
+        property("sonar.projectName", "Campus Reach Team 08")
+        property("sonar.organization", "campusreacheight")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
         property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")


### PR DESCRIPTION
Replaced automatic SonarCloud analysis with explicit CI integration
to ensure analysis runs with proper test coverage and build context.

Changes:
- Disabled automatic analysis in SonarCloud project settings
- Configured projectKey and organization in build.gradle.kts
- Added SONAR_TOKEN secret to repository settings
- Added sonar task to CI workflow after coverage generation
- Analysis now runs on all branches (main, feature/*, bugfix/*, hotfix/*)
- Results visible for default branch and pull requests