### PR TITLE
Bugfix: add Firestore and Storage security rules for user profiles an…

### DIFF
--- a/app/src/main/java/com/android/sample/model/profile/UserProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/profile/UserProfileRepositoryFirestore.kt
@@ -3,7 +3,6 @@ package com.android.sample.model.profile
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
-import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.tasks.await
@@ -28,9 +27,9 @@ class UserProfileRepositoryFirestore(private val db: FirebaseFirestore) : UserPr
   private val publicCollectionRef = db.collection(PUBLIC_PROFILES_PATH)
   private val privateCollectionRef = db.collection(PRIVATE_PROFILES_PATH)
 
-  // Near zero collision probability for user profile IDs
+  // Fix: Document ID should be the authenticated user's UID
   override fun getNewUid(): String {
-    return UUID.randomUUID().toString()
+    return Firebase.auth.currentUser?.uid ?: throw IllegalStateException("No authenticated user")
   }
 
   // Retrieves all public user profiles

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,29 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Public profiles: everyone can read
+    match /public_profiles/{userId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Private profiles: only the owner can read/write
+    match /private_profiles/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /requests/{requestId} {
+          // Create: allow only if auth UID equals creatorId in the new document
+          allow create: if request.auth != null
+                        && request.auth.uid == request.resource.data.creatorId;
+
+          // Update, Delete: allow only if auth UID equals stored creatorId
+          allow update, delete: if request.auth != null
+                                      && request.auth.uid == resource.data.creatorId;
+
+          // Read: Allow any user to read requests
+          allow read: if true;
+        }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// Craft rules based on data in your Firestore database
+// allow write: if firestore.get(
+//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces new security rules for both Firestore and Firebase Storage to control access to user profiles and requests, and to restrict storage access. The main changes are the addition of granular access controls for different data types and a locked-down default for storage.

**Firestore rules improvements:**

* Added rules to `firestore.rules` for public and private profiles:
  - Public profiles can be read by anyone, but only updated by the owner.
  - Private profiles can only be accessed by the owner.
* Added rules for `requests` documents:
  - Creation allowed only by the authenticated user matching `creatorId`.
  - Updates and deletions restricted to the creator.
  - Read access open to all users.

**Firebase Storage rules:**

* Added `storage.rules` to deny all read and write access by default, ensuring no unintended public access to files.