### PR TITLE
Feature: implement Firestore request repository and associated tests

### DIFF
--- a/app/src/androidTest/java/com/android/sample/model/request/RequestRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/sample/model/request/RequestRepositoryFirestoreTest.kt
@@ -1,0 +1,315 @@
+package com.android.sample.model.request
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.model.map.Location
+import com.android.sample.utils.FirebaseEmulator
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RequestRepositoryFirestoreTest {
+
+  private lateinit var repository: RequestRepositoryFirestore
+  private lateinit var db: FirebaseFirestore
+  private lateinit var auth: FirebaseAuth
+  private lateinit var currentUserId: String
+  private var currentEmail: String = DEFAULT_USER_EMAIL
+  private var currentPassword: String = DEFAULT_USER_PASSWORD
+
+  companion object {
+    private const val DEFAULT_USER_EMAIL = "test@example.com"
+    private const val DEFAULT_USER_PASSWORD = "test123456"
+    private const val SECOND_USER_EMAIL = "secondUser@example.com"
+    private const val SECOND_USER_PASSWORD = DEFAULT_USER_PASSWORD // unify to avoid mismatch
+  }
+
+  private data class CreatedRequest(val email: String, val password: String, val id: String)
+
+  private val createdRequests = mutableListOf<CreatedRequest>()
+
+  private suspend fun signInUser(email: String, password: String) {
+    FirebaseEmulator.signOut()
+    FirebaseEmulator.signInTestUser(email, password)
+    currentEmail = email
+    currentPassword = password
+    currentUserId = auth.currentUser?.uid ?: error("Failed to sign in user $email")
+  }
+
+  private suspend fun addRequestTracking(request: Request) {
+    repository.addRequest(request)
+    createdRequests.add(CreatedRequest(currentEmail, currentPassword, request.requestId))
+  }
+
+  private fun generateRequest(
+      requestId: String,
+      title: String,
+      description: String,
+      creatorId: String,
+      start: Date = Date(),
+      expires: Date = Date(System.currentTimeMillis() + 3_600_000)
+  ): Request {
+    return Request(
+        requestId = requestId,
+        title = title,
+        description = description,
+        requestType = listOf(RequestType.STUDYING),
+        location = Location(46.5191, 6.5668, "EPFL"),
+        locationName = "EPFL",
+        status = RequestStatus.OPEN,
+        startTimeStamp = start,
+        expirationTime = expires,
+        people = emptyList(),
+        tags = listOf(Tags.URGENT),
+        creatorId = creatorId)
+  }
+
+  private lateinit var request1: Request
+  private lateinit var request2: Request
+  private lateinit var request3: Request
+
+  @Before
+  fun setUp() {
+    db = FirebaseEmulator.firestore
+    auth = FirebaseEmulator.auth
+    repository = RequestRepositoryFirestore(db)
+
+    runTest {
+      // Ensure a clean auth state so previously created users with different passwords do not
+      // linger
+      FirebaseEmulator.clearAuthEmulator()
+      signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+      request1 =
+          generateRequest("test-request-1", "Study Session", "Need help with Math", currentUserId)
+      request2 =
+          generateRequest(
+              "test-request-2", "Lunch Together", "Looking for lunch buddy", currentUserId)
+      request3 = generateRequest("test-request-3", "Basketball Game", "Need players", currentUserId)
+      createdRequests.clear()
+    }
+  }
+
+  @After
+  fun tearDown() {
+    runTest { clearAllTestRequests() }
+    // Clean both Firestore and Auth emulators to avoid password mismatch on next test run
+    FirebaseEmulator.clearFirestoreEmulator()
+    FirebaseEmulator.clearAuthEmulator()
+    FirebaseEmulator.signOut()
+  }
+
+  private suspend fun clearAllTestRequests() {
+    // Group by user credentials and delete each user's requests while authenticated as them
+    createdRequests
+        .groupBy { it.email to it.password }
+        .forEach { (cred, reqs) ->
+          val (email, password) = cred
+          signInUser(email, password)
+          reqs.forEach { entry -> runCatching { repository.deleteRequest(entry.id) } }
+        }
+    // Return to default user for consistency
+    signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+    createdRequests.clear()
+  }
+
+  private suspend fun getRequestsCount(): Int =
+      repository.getAllRequests().size // Using repository to respect rules/logic
+
+  @Test
+  fun getNewRequestIdReturnsUniqueIDs() = runTest {
+    val numberIDs = 50
+    val requestIds = (0 until numberIDs).map { repository.getNewRequestId() }.toSet()
+    assertEquals(numberIDs, requestIds.size)
+  }
+
+  @Test
+  fun canAddRequestToRepository() = runTest {
+    addRequestTracking(request1)
+    assertEquals(1, getRequestsCount())
+    val stored = repository.getRequest(request1.requestId)
+    assertEquals(request1.requestId, stored.requestId)
+    assertEquals(request1.creatorId, stored.creatorId)
+  }
+
+  @Test
+  fun addRequestPersistsTimestamps() = runTest {
+    val start = Date()
+    val end = Date(start.time + 10_000)
+    val r = generateRequest("timed-req", "Timed", "Check times", currentUserId, start, end)
+    addRequestTracking(r)
+    val stored = repository.getRequest(r.requestId)
+    assertEquals(start.time / 1000, stored.startTimeStamp.time / 1000)
+    assertEquals(end.time / 1000, stored.expirationTime.time / 1000)
+  }
+
+  @Test
+  fun addRequestWithTheCorrectID() = runTest {
+    addRequestTracking(request1)
+    val storedRequest = repository.getRequest(request1.requestId)
+    assertEquals(request1, storedRequest)
+  }
+
+  @Test
+  fun canAddMultipleRequestsToRepository() = runTest {
+    addRequestTracking(request1)
+    addRequestTracking(request2)
+    addRequestTracking(request3)
+    assertEquals(3, getRequestsCount())
+    val ids = repository.getAllRequests().map { it.requestId }.toSet()
+    assertTrue(ids.containsAll(listOf(request1.requestId, request2.requestId, request3.requestId)))
+  }
+
+  @Test
+  fun duplicateIdOverwritesDocument() = runTest {
+    val first = request1.copy(requestId = "dup-id")
+    val second = request2.copy(requestId = "dup-id")
+    addRequestTracking(first)
+    // second overwrites same doc id; record again so cleanup attempts both (safe)
+    addRequestTracking(second)
+    val all = repository.getAllRequests()
+    val stored = repository.getRequest("dup-id")
+    assertEquals(second.title, stored.title)
+    assertEquals(second.description, stored.description)
+    assertEquals(1, all.count { it.requestId == "dup-id" })
+  }
+
+  @Test
+  fun cannotAddRequestWithMismatchedCreatorId() = runTest {
+    val bad = request1.copy(creatorId = "different-user-id")
+    try {
+      repository.addRequest(bad) // intentionally not tracked; should fail
+      fail("Expected IllegalArgumentException when adding request with mismatched creator ID")
+    } catch (_: IllegalArgumentException) {}
+    assertEquals(0, getRequestsCount())
+  }
+
+  @Test
+  fun canRetrieveRequestByID() = runTest {
+    addRequestTracking(request1)
+    addRequestTracking(request2)
+    val storedRequest = repository.getRequest(request2.requestId)
+    assertEquals(request2, storedRequest)
+  }
+
+  @Test
+  fun getRequestNotFoundThrows() = runTest {
+    try {
+      repository.getRequest("does-not-exist")
+      fail("Expected exception for missing request")
+    } catch (_: Exception) {}
+  }
+
+  @Test
+  fun canDeleteRequestByID() = runTest {
+    addRequestTracking(request1)
+    addRequestTracking(request2)
+    addRequestTracking(request3)
+    repository.deleteRequest(request2.requestId)
+    val remaining = repository.getAllRequests().map { it.requestId }
+    assertFalse(remaining.contains(request2.requestId))
+  }
+
+  @Test
+  fun cannotDeleteOtherUsersRequest() = runTest {
+    addRequestTracking(request1)
+    // sign in as second user & create their request
+    signInUser(SECOND_USER_EMAIL, SECOND_USER_PASSWORD)
+    val secondUserRequest = generateRequest("other-user-request", "Other", "Desc", currentUserId)
+    addRequestTracking(secondUserRequest)
+    // back to default user
+    signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+    try {
+      repository.deleteRequest(secondUserRequest.requestId)
+      fail("Expected IllegalArgumentException when deleting another user's request")
+    } catch (_: IllegalArgumentException) {}
+  }
+
+  @Test
+  fun canUpdateRequestByID() = runTest {
+    addRequestTracking(request1)
+    val modified = request1.copy(title = "Modified Title", status = RequestStatus.COMPLETED)
+    repository.updateRequest(request1.requestId, modified)
+    val stored = repository.getRequest(request1.requestId)
+    assertEquals(modified, stored)
+  }
+
+  @Test
+  fun canUpdateTheCorrectRequestByID() = runTest {
+    addRequestTracking(request1)
+    addRequestTracking(request2)
+    val modified = request1.copy(title = "Modified Title", status = RequestStatus.IN_PROGRESS)
+    repository.updateRequest(request1.requestId, modified)
+    val storedModified = repository.getRequest(request1.requestId)
+    assertEquals(modified, storedModified)
+    val storedOther = repository.getRequest(request2.requestId)
+    assertEquals(request2.title, storedOther.title)
+  }
+
+  @Test
+  fun cannotUpdateOtherUsersRequest() = runTest {
+    addRequestTracking(request1)
+    signInUser(SECOND_USER_EMAIL, SECOND_USER_PASSWORD)
+    val secondUsersRequest = generateRequest("second-user-request", "Second", "Desc", currentUserId)
+    addRequestTracking(secondUsersRequest)
+    signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+    try {
+      repository.updateRequest(
+          secondUsersRequest.requestId, secondUsersRequest.copy(title = "Hacked"))
+      fail("Expected IllegalArgumentException when updating another user's request")
+    } catch (_: IllegalArgumentException) {}
+  }
+
+  @Test
+  fun cannotUpdateRequestIdDuringUpdate() = runTest {
+    addRequestTracking(request1)
+    val modified = request1.copy(requestId = "different-id")
+    try {
+      repository.updateRequest(request1.requestId, modified)
+      fail("Expected IllegalArgumentException when changing request ID during update")
+    } catch (_: IllegalArgumentException) {}
+  }
+
+  @Test
+  fun unauthenticatedOperationsThrow() = runTest {
+    addRequestTracking(request1)
+    FirebaseEmulator.signOut()
+    // Add
+    try {
+      repository.addRequest(request2)
+      fail("Expected IllegalStateException when adding unauthenticated")
+    } catch (_: IllegalStateException) {}
+    // Update
+    try {
+      repository.updateRequest(request1.requestId, request1.copy(title = "NoAuth"))
+      fail("Expected IllegalStateException when updating unauthenticated")
+    } catch (_: IllegalStateException) {}
+    // Delete
+    try {
+      repository.deleteRequest(request1.requestId)
+      fail("Expected IllegalStateException when deleting unauthenticated")
+    } catch (_: IllegalStateException) {}
+    // Re-sign in default for any further cleanup
+    signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+  }
+
+  @Test
+  fun multiUserRequestsVisibleToAll() = runTest {
+    addRequestTracking(request1) // user A
+    signInUser(SECOND_USER_EMAIL, SECOND_USER_PASSWORD)
+    val secondReq = generateRequest("second-user-request", "Second", "Desc", currentUserId)
+    addRequestTracking(secondReq)
+    // User B view
+    val userBIds = repository.getAllRequests().map { it.requestId }.toSet()
+    assertTrue(userBIds.containsAll(listOf(request1.requestId, secondReq.requestId)))
+    // Switch back to A
+    signInUser(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
+    val userAIds = repository.getAllRequests().map { it.requestId }.toSet()
+    assertTrue(userAIds.containsAll(listOf(request1.requestId, secondReq.requestId)))
+  }
+}

--- a/app/src/main/java/com/android/sample/model/request/Request.kt
+++ b/app/src/main/java/com/android/sample/model/request/Request.kt
@@ -1,6 +1,8 @@
 package com.android.sample.model.request
 
 import com.android.sample.model.map.Location
+import com.google.firebase.Timestamp
+import java.util.Date
 
 data class Request(
     val requestId: String,
@@ -12,12 +14,63 @@ data class Request(
     val location: Location,
     val locationName: String,
     val status: RequestStatus,
-    val startTimeStamp: Long,
-    val expirationTime: Long,
+    val startTimeStamp: Date,
+    val expirationTime: Date,
     val people: List<String>,
     val tags: List<Tags>,
     val creatorId: String
-)
+) {
+  companion object {
+    fun fromMap(map: Map<String, Any?>): Request {
+      // Basic presence validation (will throw if missing)
+      fun <T> req(key: String): T = map[key] as T
+
+      val loc = map["location"]
+      val location =
+          if (loc is Map<*, *>) {
+            Location(
+                latitude = loc["latitude"] as Double,
+                longitude = loc["longitude"] as Double,
+                name = loc["name"] as String)
+          } else {
+            Location(0.0, 0.0, "")
+          }
+
+      return Request(
+          requestId = req("requestId"),
+          title = req("title"),
+          description = req("description"),
+          requestType = (req<List<*>>("requestType")).map { RequestType.valueOf(it as String) },
+          location = location,
+          locationName = req("locationName"),
+          status = RequestStatus.valueOf(req("status")),
+          startTimeStamp = (req<Timestamp>("startTimeStamp")).toDate(),
+          expirationTime = (req<Timestamp>("expirationTime")).toDate(),
+          people = (req<List<*>>("people")).map { it as String },
+          tags = (req<List<*>>("tags")).map { Tags.valueOf(it as String) },
+          creatorId = req("creatorId"))
+    }
+  }
+
+  fun toMap(): Map<String, Any?> =
+      mapOf(
+          "requestId" to requestId,
+          "title" to title,
+          "description" to description,
+          "requestType" to requestType.map { it.name },
+          "location" to
+              mapOf(
+                  "latitude" to location.latitude,
+                  "longitude" to location.longitude,
+                  "name" to location.name),
+          "locationName" to locationName,
+          "status" to status.name,
+          "startTimeStamp" to Timestamp(startTimeStamp),
+          "expirationTime" to Timestamp(expirationTime),
+          "people" to people,
+          "tags" to tags.map { it.name },
+          "creatorId" to creatorId)
+}
 
 enum class RequestStatus {
   OPEN,

--- a/app/src/main/java/com/android/sample/model/request/RequestRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/request/RequestRepositoryFirestore.kt
@@ -1,0 +1,82 @@
+package com.android.sample.model.request
+
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.ktx.Firebase
+import java.util.UUID
+import kotlinx.coroutines.tasks.await
+
+const val REQUESTS_COLLECTION_PATH = "requests"
+
+class RequestRepositoryFirestore(
+    private val db: FirebaseFirestore,
+) : RequestRepository {
+  // Path structure: "requests/{requestId}"
+
+  private val collectionRef = db.collection(REQUESTS_COLLECTION_PATH)
+
+  private fun notAuthenticated(): Unit = throw IllegalStateException("No authenticated user")
+
+  private fun notAuthorized(): Unit =
+      throw IllegalArgumentException("Can only modify the currently authenticated user's requests")
+
+  override fun getNewRequestId(): String {
+    return UUID.randomUUID().toString()
+  }
+
+  override suspend fun getAllRequests(): List<Request> {
+    return collectionRef.get().await().documents.mapNotNull { doc ->
+      doc.data?.let { Request.fromMap(it) }
+    }
+  }
+
+  override suspend fun getRequest(requestId: String): Request {
+    return collectionRef
+        .whereEqualTo("requestId", requestId)
+        .get()
+        .await()
+        .documents
+        .firstNotNullOfOrNull { doc -> doc.data?.let { Request.fromMap(it) } }
+        ?: throw Exception("Request with ID $requestId not found")
+  }
+
+  override suspend fun addRequest(request: Request) {
+    val currentUserId = Firebase.auth.currentUser?.uid ?: notAuthenticated()
+
+    if (request.creatorId != currentUserId) {
+      notAuthorized()
+    }
+
+    collectionRef.document(request.requestId).set(request.toMap()).await()
+  }
+
+  override suspend fun updateRequest(requestId: String, updatedRequest: Request) {
+    val currentUserId = Firebase.auth.currentUser?.uid ?: notAuthenticated()
+
+    // Verify the request exists
+    val existingRequest = getRequest(requestId)
+
+    if (existingRequest.creatorId != currentUserId) {
+      notAuthorized()
+    }
+
+    if (requestId != updatedRequest.requestId) {
+      throw IllegalArgumentException("Request ID cannot be changed")
+    }
+
+    collectionRef.document(requestId).set(updatedRequest.toMap()).await()
+  }
+
+  override suspend fun deleteRequest(requestId: String) {
+    val currentUserId = Firebase.auth.currentUser?.uid ?: notAuthenticated()
+
+    // Verify the request exists before deleting
+    val existingRequest = getRequest(requestId)
+
+    if (existingRequest.creatorId != currentUserId) {
+      notAuthorized()
+    }
+
+    collectionRef.document(requestId).delete().await()
+  }
+}

--- a/app/src/test/java/com/android/sample/model/request/RequestTest.kt
+++ b/app/src/test/java/com/android/sample/model/request/RequestTest.kt
@@ -1,0 +1,403 @@
+package com.android.sample.model.request
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.model.map.Location
+import com.google.firebase.Timestamp
+import java.util.Date
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RequestTest {
+
+  private fun createTestRequest(
+      requestId: String = "test-request-1",
+      title: String = "Study Session",
+      description: String = "Need help with Math",
+      creatorId: String = "user123"
+  ): Request {
+    return Request(
+        requestId = requestId,
+        title = title,
+        description = description,
+        requestType = listOf(RequestType.STUDYING),
+        location = Location(46.5191, 6.5668, "EPFL"),
+        locationName = "EPFL",
+        status = RequestStatus.OPEN,
+        startTimeStamp = Date(System.currentTimeMillis()),
+        expirationTime = Date(System.currentTimeMillis() + 3600000),
+        people = listOf("user1", "user2"),
+        tags = listOf(Tags.URGENT, Tags.INDOOR),
+        creatorId = creatorId)
+  }
+
+  @Test
+  fun toMap_and_fromMap_symmetry() {
+    val request = createTestRequest()
+    val map = request.toMap()
+
+    // Verify map contains correct keys
+    assertEquals(request.requestId, map["requestId"])
+    assertEquals(request.title, map["title"])
+    assertEquals(request.description, map["description"])
+    assertEquals(request.locationName, map["locationName"])
+    assertEquals(request.status.name, map["status"])
+    assertEquals(request.creatorId, map["creatorId"])
+
+    // Verify timestamps are Timestamp objects
+    assertTrue(map["startTimeStamp"] is Timestamp)
+    assertTrue(map["expirationTime"] is Timestamp)
+
+    // Reconstruct from map
+    val reconstructed = Request.fromMap(map)
+
+    // Verify all fields match
+    assertEquals(request.requestId, reconstructed.requestId)
+    assertEquals(request.title, reconstructed.title)
+    assertEquals(request.description, reconstructed.description)
+    assertEquals(request.requestType, reconstructed.requestType)
+    assertEquals(request.location.latitude, reconstructed.location.latitude, 0.0001)
+    assertEquals(request.location.longitude, reconstructed.location.longitude, 0.0001)
+    assertEquals(request.location.name, reconstructed.location.name)
+    assertEquals(request.locationName, reconstructed.locationName)
+    assertEquals(request.status, reconstructed.status)
+    assertEquals(request.startTimeStamp.time / 1000, reconstructed.startTimeStamp.time / 1000)
+    assertEquals(request.expirationTime.time / 1000, reconstructed.expirationTime.time / 1000)
+    assertEquals(request.people, reconstructed.people)
+    assertEquals(request.tags, reconstructed.tags)
+    assertEquals(request.creatorId, reconstructed.creatorId)
+  }
+
+  @Test
+  fun toMap_requestTypeList_correctlySerialized() {
+    val request =
+        createTestRequest().copy(requestType = listOf(RequestType.STUDYING, RequestType.EATING))
+    val map = request.toMap()
+
+    @Suppress("UNCHECKED_CAST") val typeList = map["requestType"] as List<String>
+    assertEquals(2, typeList.size)
+    assertTrue(typeList.contains("STUDYING"))
+    assertTrue(typeList.contains("EATING"))
+  }
+
+  @Test
+  fun fromMap_requestTypeList_correctlyDeserialized() {
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("STUDYING", "SPORT"),
+            "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668, "name" to "EPFL"),
+            "locationName" to "EPFL",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to listOf("URGENT"),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertEquals(2, request.requestType.size)
+    assertTrue(request.requestType.contains(RequestType.STUDYING))
+    assertTrue(request.requestType.contains(RequestType.SPORT))
+  }
+
+  @Test
+  fun toMap_locationObject_correctlySerialized() {
+    val location = Location(47.3769, 8.5417, "Zurich")
+    val request = createTestRequest().copy(location = location, locationName = "Zurich")
+    val map = request.toMap()
+
+    @Suppress("UNCHECKED_CAST") val locationMap = map["location"] as Map<String, Any?>
+    assertEquals(47.3769, locationMap["latitude"] as Double, 0.0001)
+    assertEquals(8.5417, locationMap["longitude"] as Double, 0.0001)
+    assertEquals("Zurich", locationMap["name"])
+  }
+
+  @Test
+  fun fromMap_locationObject_correctlyDeserialized() {
+    val locationMap = mapOf("latitude" to 47.3769, "longitude" to 8.5417, "name" to "Zurich")
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("EATING"),
+            "location" to locationMap,
+            "locationName" to "Zurich",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to listOf("INDOOR"),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertEquals(47.3769, request.location.latitude, 0.0001)
+    assertEquals(8.5417, request.location.longitude, 0.0001)
+    assertEquals("Zurich", request.location.name)
+  }
+
+  @Test
+  fun toMap_tagsList_correctlySerialized() {
+    val request =
+        createTestRequest().copy(tags = listOf(Tags.URGENT, Tags.GROUP_WORK, Tags.OUTDOOR))
+    val map = request.toMap()
+
+    @Suppress("UNCHECKED_CAST") val tagsList = map["tags"] as List<String>
+    assertEquals(3, tagsList.size)
+    assertTrue(tagsList.contains("URGENT"))
+    assertTrue(tagsList.contains("GROUP_WORK"))
+    assertTrue(tagsList.contains("OUTDOOR"))
+  }
+
+  @Test
+  fun fromMap_tagsList_correctlyDeserialized() {
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("OTHER"),
+            "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668, "name" to "EPFL"),
+            "locationName" to "EPFL",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to listOf("EASY", "SOLO_WORK"),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertEquals(2, request.tags.size)
+    assertTrue(request.tags.contains(Tags.EASY))
+    assertTrue(request.tags.contains(Tags.SOLO_WORK))
+  }
+
+  @Test
+  fun toMap_peopleList_correctlySerialized() {
+    val request = createTestRequest().copy(people = listOf("user1", "user2", "user3"))
+    val map = request.toMap()
+
+    @Suppress("UNCHECKED_CAST") val peopleList = map["people"] as List<String>
+    assertEquals(3, peopleList.size)
+    assertTrue(peopleList.contains("user1"))
+    assertTrue(peopleList.contains("user2"))
+    assertTrue(peopleList.contains("user3"))
+  }
+
+  @Test
+  fun fromMap_peopleList_correctlyDeserialized() {
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("HANGING_OUT"),
+            "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668, "name" to "EPFL"),
+            "locationName" to "EPFL",
+            "status" to "IN_PROGRESS",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to listOf("alice", "bob", "charlie"),
+            "tags" to emptyList<String>(),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertEquals(3, request.people.size)
+    assertTrue(request.people.contains("alice"))
+    assertTrue(request.people.contains("bob"))
+    assertTrue(request.people.contains("charlie"))
+  }
+
+  @Test
+  fun toMap_timestampsAsFirebaseTimestamp() {
+    val now = Date()
+    val later = Date(now.time + 7200000) // 2 hours later
+    val request = createTestRequest().copy(startTimeStamp = now, expirationTime = later)
+    val map = request.toMap()
+
+    val startTimestamp = map["startTimeStamp"] as Timestamp
+    val expireTimestamp = map["expirationTime"] as Timestamp
+
+    assertEquals(now.time / 1000, startTimestamp.toDate().time / 1000)
+    assertEquals(later.time / 1000, expireTimestamp.toDate().time / 1000)
+  }
+
+  @Test
+  fun fromMap_timestampsConvertedToDate() {
+    val now = Date()
+    val later = Date(now.time + 3600000)
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("STUDYING"),
+            "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668, "name" to "EPFL"),
+            "locationName" to "EPFL",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(now),
+            "expirationTime" to Timestamp(later),
+            "people" to emptyList<String>(),
+            "tags" to emptyList<String>(),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertTrue(request.startTimeStamp is Date)
+    assertTrue(request.expirationTime is Date)
+    assertEquals(now.time / 1000, request.startTimeStamp.time / 1000)
+    assertEquals(later.time / 1000, request.expirationTime.time / 1000)
+  }
+
+  @Test
+  fun requestStatus_allValuesSerializeCorrectly() {
+    RequestStatus.values().forEach { status ->
+      val request = createTestRequest().copy(status = status)
+      val map = request.toMap()
+      assertEquals(status.name, map["status"])
+
+      val reconstructed = Request.fromMap(map)
+      assertEquals(status, reconstructed.status)
+    }
+  }
+
+  @Test
+  fun requestType_allValuesSerializeCorrectly() {
+    RequestType.values().forEach { type ->
+      val request = createTestRequest().copy(requestType = listOf(type))
+      val map = request.toMap()
+
+      @Suppress("UNCHECKED_CAST") val typeList = map["requestType"] as List<String>
+      assertTrue(typeList.contains(type.name))
+
+      val reconstructed = Request.fromMap(map)
+      assertTrue(reconstructed.requestType.contains(type))
+    }
+  }
+
+  @Test
+  fun tags_allValuesSerializeCorrectly() {
+    Tags.values().forEach { tag ->
+      val request = createTestRequest().copy(tags = listOf(tag))
+      val map = request.toMap()
+
+      @Suppress("UNCHECKED_CAST") val tagsList = map["tags"] as List<String>
+      assertTrue(tagsList.contains(tag.name))
+
+      val reconstructed = Request.fromMap(map)
+      assertTrue(reconstructed.tags.contains(tag))
+    }
+  }
+
+  @Test
+  fun fromMap_emptyLists_handledCorrectly() {
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to emptyList<String>(),
+            "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668, "name" to "EPFL"),
+            "locationName" to "EPFL",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to emptyList<String>(),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertTrue(request.requestType.isEmpty())
+    assertTrue(request.people.isEmpty())
+    assertTrue(request.tags.isEmpty())
+  }
+
+  @Test
+  fun fromMap_nullLocation_createsDefaultLocation() {
+    val map =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("OTHER"),
+            "location" to null,
+            "locationName" to "Unknown",
+            "status" to "OPEN",
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to emptyList<String>(),
+            "creatorId" to "user123")
+
+    val request = Request.fromMap(map)
+    assertEquals(0.0, request.location.latitude, 0.0001)
+    assertEquals(0.0, request.location.longitude, 0.0001)
+    assertEquals("", request.location.name)
+  }
+
+  @Test(expected = NullPointerException::class)
+  fun fromMap_missingRequiredKey_throwsException() {
+    // Remove a required key (e.g. status)
+    val badMap =
+        mapOf(
+            "requestId" to "req1",
+            "title" to "Test",
+            "description" to "Desc",
+            "requestType" to listOf("OTHER"),
+            "location" to mapOf("latitude" to 0.0, "longitude" to 0.0, "name" to "Nowhere"),
+            "locationName" to "Nowhere",
+            // "status" missing
+            "startTimeStamp" to Timestamp(Date()),
+            "expirationTime" to Timestamp(Date(System.currentTimeMillis() + 3600000)),
+            "people" to emptyList<String>(),
+            "tags" to emptyList<String>(),
+            "creatorId" to "user123")
+    // This should throw
+    Request.fromMap(badMap)
+  }
+
+  @Test
+  fun toMap_allFieldsPresent() {
+    val request = createTestRequest()
+    val map = request.toMap()
+
+    // Verify all required fields are present
+    assertTrue(map.containsKey("requestId"))
+    assertTrue(map.containsKey("title"))
+    assertTrue(map.containsKey("description"))
+    assertTrue(map.containsKey("requestType"))
+    assertTrue(map.containsKey("location"))
+    assertTrue(map.containsKey("locationName"))
+    assertTrue(map.containsKey("status"))
+    assertTrue(map.containsKey("startTimeStamp"))
+    assertTrue(map.containsKey("expirationTime"))
+    assertTrue(map.containsKey("people"))
+    assertTrue(map.containsKey("tags"))
+    assertTrue(map.containsKey("creatorId"))
+  }
+
+  @Test
+  fun request_copyWorks() {
+    val original = createTestRequest()
+    val copy = original.copy(title = "New Title", status = RequestStatus.COMPLETED)
+
+    assertEquals("New Title", copy.title)
+    assertEquals(RequestStatus.COMPLETED, copy.status)
+    assertEquals(original.requestId, copy.requestId)
+    assertEquals(original.description, copy.description)
+    assertEquals(original.creatorId, copy.creatorId)
+  }
+
+  @Test
+  fun request_equalityWorks() {
+    val request1 = createTestRequest(requestId = "same-id")
+    val request2 = createTestRequest(requestId = "same-id")
+    val request3 = createTestRequest(requestId = "different-id")
+
+    assertEquals(request1, request2)
+    assertNotEquals(request1, request3)
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Firestore-backed implementation for request data management, updates the `Request` data model to use proper timestamp handling, and adds a comprehensive suite of Android instrumentation tests to ensure correct behavior for all request operations. The changes improve data consistency, enforce authentication and authorization rules, and provide robust test coverage for multi-user scenarios.

**Firestore Integration and Data Model Update:**

* Added `RequestRepositoryFirestore` as a new implementation of the `RequestRepository` interface, using Firestore for storing and retrieving requests, with strict authentication and authorization checks for all modifying operations.
* Updated the `Request` data class to use `Date` for `startTimeStamp` and `expirationTime` instead of `Long`, and implemented `fromMap` and `toMap` methods for seamless Firestore serialization/deserialization.

**Testing Improvements:**

* Added a full instrumentation test suite in `RequestRepositoryFirestoreTest.kt` covering request creation, retrieval, update, deletion, multi-user access, and error cases such as unauthorized or unauthenticated operations.

**Other Model Adjustments:**

* Updated imports in `Request.kt` to support new timestamp handling with Firestore.

Closes #31 