### PR TITLE
fix(testing): update JaCoCo version to 0.8.13 for improved coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 
     testCoverage {
-        jacocoVersion = "0.8.11"
+        jacocoVersion = "0.8.13"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -102,7 +102,7 @@ android {
     }
 }
 jacoco {
-    toolVersion = "0.8.11"
+    toolVersion = "0.8.13"
 }
 sonar {
     properties {


### PR DESCRIPTION
This pull request updates the Jacoco code coverage tool version in the Gradle build configuration to improve compatibility and ensure the latest features and fixes are available.

Dependency version updates:

* Updated `jacocoVersion` in the `android.testCoverage` section of `app/build.gradle.kts` from `0.8.11` to `0.8.13`.
* Updated `toolVersion` in the `jacoco` section of `app/build.gradle.kts` from `0.8.11` to `0.8.13`.