### PR TITLE
feat: add pre-commit hook for formatting checks with ktfmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo "[pre-commit] Checking formatting with ktfmt..."
+
+./gradlew ktfmtCheck --quiet
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+  echo "[pre-commit] Some files are not properly formatted."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This pull request adds a new pre-commit hook to enforce Kotlin code formatting standards during local development.

Code quality enforcement:

* Added a `.githooks/pre-commit` script that checks code formatting using `ktfmt` and prevents commits if files are not properly formatted.