### PR TITLE
feat(build): add GitHub Actions workflow for building Android APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build Android APK
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'M1'
+      - 'M2'
+      - 'M3'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build APK
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/*.apk
+          retention-days: 30


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of building and uploading an Android APK when changes are pushed to the `main` branch or specific tags. This helps streamline the release process and ensures consistent builds.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/build.yml` that:
  - Triggers on pushes to `main` and tags `M1`, `M2`, or `M3`, as well as manual dispatches.
  - Sets up the build environment with JDK 17 and Gradle caching.
  - Checks out the repository and grants execute permissions to `gradlew`.
  - Builds the Android APK using the `assembleRelease` Gradle task.
  - Uploads the generated APK as a build artifact with a 30-day retention period.