### PR TITLE
Fix: implement Google Sign-In fallback for Android 14 and below

### DIFF
--- a/app/src/main/java/com/android/sample/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignInScreen.kt
@@ -107,7 +107,7 @@ fun SignInScreen(
             } catch (e: NoCredentialException) {
               viewModel.setError("No Google account found")
             } catch (e: GetCredentialException) {
-              viewModel.setError("Google Sign-In cancelled")
+              viewModel.setError("Connection cancelled")
             }
           }
           else -> viewModel.setError("Connection error: ${e.localizedMessage}")


### PR DESCRIPTION
This pull request updates the Google Sign-In logic in the `SignInScreen` to support both Android 15+ and Android 14 and below, ensuring broader compatibility and a smoother user experience. The main changes introduce a fallback mechanism for older Android versions and update error handling accordingly.

**Authentication logic improvements:**

* Added support for Android 14 and below by introducing a fallback using `GetGoogleIdOption` when a sign-in cancellation occurs, ensuring users on older devices can still sign in with Google.
* Imported `GetGoogleIdOption` to enable the fallback implementation for legacy Android versions.
* Enhanced error handling by differentiating between no Google account found and sign-in cancellation scenarios, improving user feedback.

**Documentation and clarity:**

* Added comments to clarify the distinction between the Android 15+ sign-in flow and the fallback for Android 14 and below. [[1]](diffhunk://#diff-2b829aa899bd5f733025d286d3ece7a7e0d6f7144473c7c54a70f97d86ea12c8R81) [[2]](diffhunk://#diff-2b829aa899bd5f733025d286d3ece7a7e0d6f7144473c7c54a70f97d86ea12c8L90-R112)

Fixes #113 