### PR TITLE
fix(ui): add window insets padding to bottom navigation bar

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -3,6 +3,7 @@ package com.android.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -23,6 +24,7 @@ import com.android.sample.ui.theme.SampleAppTheme
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
 
     setContent {
       SampleAppTheme {

--- a/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
@@ -1,7 +1,10 @@
 package com.android.sample.ui.navigation
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
@@ -41,6 +44,7 @@ fun BottomNavigationMenu(
       modifier =
           modifier
               .fillMaxWidth()
+              .windowInsetsPadding(WindowInsets.navigationBars)
               .height(UiDimens.ButtonHeight)
               .testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU),
       containerColor = appPalette().surface,


### PR DESCRIPTION
## Fix bottom navigation bar being cut off by system UI

### Problem
The bottom navigation bar was being overlapped by the Android system navigation bar, causing the bottom portion to be cut off and reducing usability.

### Solution
- Enabled edge-to-edge display mode in `MainActivity` using `enableEdgeToEdge()`
- Added `windowInsetsPadding(WindowInsets.navigationBars)` to `BottomNavigationMenu` to properly handle system UI insets
- This ensures the bottom navigation bar respects the system navigation bar height and remains fully visible

### Changes Made
- `MainActivity.kt`: Added `enableEdgeToEdge()` call in `onCreate()`
- `BottomNavigationMenu.kt`: Added window insets padding to the NavigationBar modifier
### No tests 
### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---
