### PR TITLE
Fix the bug of 0 pourcent coverage on sonarcloud

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Plugins
-agp = "8.11.0"
+agp = "8.4.2"
 json = "20240303"
 kotlin = "1.9.0"
 gms = "4.4.2"


### PR DESCRIPTION
## ✨ Summary
Revert Android Gradle Plugin (AGP) version from 8.11.0 to 8.4.2 to restore proper JaCoCo test coverage reporting.

Addresses #164 

---

## 📦 What's Included
### Build Configuration
* Reverted agp version in libs.versions.toml

### Reason for Reversion
* **Issue**
  * After upgrading to AGP 8.11.0, several tests show incorrect coverage (0–4%) despite being executed.
* **Impact**
  * Coverage regression of ~80% on affected tests.
* **Fix**
  * Reverting to 8.4.2 restores expected coverage results while maintaining build stability.


---

## 🧪 Testing
### Validation Steps
* Ran connectedDebugAndroidTest locally with agp = 8.4.2
  * ✅ Coverage restored to previous levels (80–90% for affected tests)

* Verified no breaking changes in build or dependency resolution
---


## 📸 Previous code coverage 🤮 
<img width="1087" height="223" alt="Capture d&#39;écran 2025-11-07 214749" src="https://github.com/user-attachments/assets/3bbca18d-bd7b-4a81-a2ca-5a8f93cdafb7" />



## 📸 Current code coverage 😄 
<img width="1457" height="79" alt="Capture d&#39;écran 2025-11-07 214739" src="https://github.com/user-attachments/assets/71305422-afb8-4a6b-a429-0cc91862f192" />
<img width="1232" height="80" alt="Capture d&#39;écran 2025-11-07 214711" src="https://github.com/user-attachments/assets/987d1a04-7c8b-45aa-92c4-3bf0c6f163db" />


---

## 📝 Notes
### AI Usage Disclosure
⚠️ **AI tools were used** to assist with debugging and documentation writing for this PR.
### Sonar cloud coverage
* Since I haven't write any code other than the agp version, it's normal that the sonar cloud say that the coverage for this PR is 0%

Closes #164