### PR TITLE
test(e2e): add request creation and editing flow tests

### DIFF
--- a/app/src/androidTest/java/com/android/sample/utils/BaseEmulatorTest.kt
+++ b/app/src/androidTest/java/com/android/sample/utils/BaseEmulatorTest.kt
@@ -15,6 +15,7 @@ import org.junit.Before
  * super.setUp()/super.tearDown().
  */
 const val UI_WAIT_TIMEOUT = 5_000L
+const val UI_BIG_WAIT_TIMEOUT = 20_000L
 
 abstract class BaseEmulatorTest {
 

--- a/app/src/main/java/com/android/sample/config/AppTestConfig.kt
+++ b/app/src/main/java/com/android/sample/config/AppTestConfig.kt
@@ -1,0 +1,6 @@
+package com.android.sample.config
+
+// Is used for saying if you are in test (true = in test)
+object AppTestConfig {
+  var isTestMode = false
+}

--- a/app/src/main/java/com/android/sample/ui/map/ConstantMap.kt
+++ b/app/src/main/java/com/android/sample/ui/map/ConstantMap.kt
@@ -90,4 +90,9 @@ object ConstantMap {
   val FONT_SIZE_BIG = 18.sp
   val FONT_SIZE_MID = 15.sp
   const val ALPHA_KUDOS_DIVIDER = 0.17f
+
+  // ======================
+  // Test
+  // ======================
+  val BOX_SIZE = 48.dp
 }

--- a/app/src/main/java/com/android/sample/ui/map/Map.kt
+++ b/app/src/main/java/com/android/sample/ui/map/Map.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -47,6 +48,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -63,6 +65,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.sample.config.AppTestConfig
 import com.android.sample.model.profile.UserProfile
 import com.android.sample.model.request.Request
 import com.android.sample.ui.navigation.BottomNavigationMenu
@@ -115,6 +118,10 @@ object MapTestTags {
   fun testTagForTab(tab: String): String {
     return "tag${tab}"
   }
+
+  fun testTagForBoxTest(id: String): String {
+    return "marker_target_$id"
+  }
 }
 
 private const val ZOOM_FEW = 15f
@@ -134,6 +141,10 @@ fun calculateZoomLevel(markerCount: Int): Float {
 fun MapScreen(viewModel: MapViewModel = viewModel(), navigationActions: NavigationActions? = null) {
   val uiState by viewModel.uiState.collectAsState()
   val appPalette = appPalette()
+
+  val enableTestOverlays: Boolean = AppTestConfig.isTestMode
+
+  var isMapReady by remember { mutableStateOf(false) }
 
   val errorMsg = uiState.errorMsg
 
@@ -182,7 +193,8 @@ fun MapScreen(viewModel: MapViewModel = viewModel(), navigationActions: Navigati
           GoogleMap(
               modifier = Modifier.fillMaxSize().testTag(MapTestTags.GOOGLE_MAP_SCREEN),
               cameraPositionState = cameraPositionState,
-              uiSettings = uiSettings) {
+              uiSettings = uiSettings,
+              onMapLoaded = { isMapReady = true }) {
                 uiState.request.forEach { request ->
                   val markerState =
                       MarkerState(
@@ -588,6 +600,26 @@ fun MapScreen(viewModel: MapViewModel = viewModel(), navigationActions: Navigati
                     CameraUpdateFactory.newLatLngZoom(
                         uiState.target, calculateZoomLevel(uiState.request.size)),
                 durationMs = 1000)
+          }
+        }
+
+        if (enableTestOverlays && isMapReady) {
+          uiState.request.forEach { request ->
+            val projection = cameraPositionState.projection
+            val screenPosition =
+                projection?.toScreenLocation(
+                    LatLng(request.location.latitude, request.location.longitude))
+
+            screenPosition?.let { position ->
+              // We use this box to target the click (on the marker of the request)
+              Box(
+                  modifier =
+                      Modifier.offset(
+                              x = with(LocalDensity.current) { position.x.toDp() },
+                              y = with(LocalDensity.current) { position.y.toDp() })
+                          .size(ConstantMap.BOX_SIZE)
+                          .testTag(MapTestTags.testTagForBoxTest(request.requestId)))
+            }
           }
         }
       })


### PR DESCRIPTION
## Add Comprehensive End-to-End Tests for Request Management

### Summary
This PR adds two critical end-to-end tests that validate the complete user workflows for request creation, editing, and navigation across multiple screens.

### Changes
Added two new E2E tests in `EndToEndTests.kt`:

1. **`canCreateRequestWithCurrentLocationEditOnMapAndLogout`**
   - Creates a request with current location
   - Navigates to map and verifies the request appears
   - Returns to request list via bottom navigation
   - Edits the request from the list
   - Navigates back to map and verifies the edit persisted
   - Completes with user logout

2. **`canCreateAndDeleteRequest`**
   - Creates a request
   - verifies informations
   - deletes the request
   - logout

### Technical Details
- Implemented proper wait strategies for async operations (save, navigation, UI recomposition)
- Added `Thread.sleep()` calls at critical points to handle async Firebase operations and keyboard animations
- Used correct navigation test tags (`REQUEST_TAB` not `REQUESTS_TAB`)
- Verified cross-screen data persistence and UI state updates
- Tests use the map screen click interaction pattern (clicking map screen directly) instead of test trigger buttons

### Testing
- [x] Both tests pass consistently on emulator
- [x] Tests verify data persistence across screen transitions
- [x] Tests handle async operations correctly (keyboard, save, navigation)
- [x] All assertions validate expected UI state

### Why This Matters
These tests ensure that:
- Request creation and editing work end-to-end across multiple screens
- Navigation between Map, Request List, and Edit screens maintains data integrity
- Async operations (save, database updates) complete before UI verification
- The complete user flow from login to logout functions correctly

### Related Issues
- Addresses issue #160 

### AI usage disolsure
Ai was used to help document and with some of the implementation