### PR TITLE
feat(profile): add profile name display

### DIFF
--- a/app/src/androidTest/java/com/android/sample/request/RequestListTests.kt
+++ b/app/src/androidTest/java/com/android/sample/request/RequestListTests.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -705,6 +706,23 @@ class RequestListTests : BaseEmulatorTest() {
           .onAllNodesWithTag(ProfilePictureTestTags.PROFILE_PICTURE, useUnmergedTree = true)
           .fetchSemanticsNodes()
           .size == 3
+    }
+  }
+
+  fun loadsProfileNameSuccessfully() {
+    val requests = sampleRequests(listOf("special_profile4"))
+    val vm =
+        RequestListViewModel(
+            FakeRequestRepository(requests),
+            FakeUserProfileRepository(withImage = setOf("special_profile4")))
+
+    composeTestRule.setContent { RequestListScreen(requestListViewModel = vm) }
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(OFFSET_5_S_MS) {
+      composeTestRule
+          .onAllNodesWithText("John", useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .size == 1
     }
   }
 }

--- a/app/src/main/java/com/android/sample/ui/request/ConstantRequestList.kt
+++ b/app/src/main/java/com/android/sample/ui/request/ConstantRequestList.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.request
 
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * Constants for RequestList UI. Avoid magic numbers: use these values for sizing/spacing. Mirrors
@@ -16,7 +17,9 @@ object ConstantRequestList {
   // List and items
   val ListPadding = 16.dp
   val ListItemSpacing = 8.dp
-  val RequestItemIconSize = 40.dp
+  val RequestItemIconSize = 47.dp
+  val RequestItemNameFontSize = 11.sp
+  val RequestItemCreatorSectionSize = 65.dp
   val RequestItemInnerPadding = 8.dp
 
   // Search bar

--- a/app/src/main/java/com/android/sample/ui/request/RequestList.kt
+++ b/app/src/main/java/com/android/sample/ui/request/RequestList.kt
@@ -193,8 +193,9 @@ fun RequestListItem(
           profileId = request.creatorId,
           onClick = {},
           modifier =
-              Modifier.size(ConstantRequestList.RequestItemIconSize)
-                  .align(Alignment.CenterVertically))
+              Modifier.size(ConstantRequestList.RequestItemCreatorSectionSize)
+                  .align(Alignment.CenterVertically),
+          withName = true)
       Spacer(Modifier.width(ConstantRequestList.RowSpacing))
       Column(Modifier.fillMaxWidth()) {
         Row(Modifier.fillMaxWidth()) {


### PR DESCRIPTION
This pull request introduces enhancements to the user profile display on request list items, including visual and test improvements. The most significant changes are the addition of profile name rendering alongside profile pictures, updates to layout sizing constants, and corresponding test coverage.

**Profile display enhancements:**

* The `ProfilePicture` composable now optionally displays the user's name below their profile picture when `withName` is set to `true`, using a new test tag and font size constant for accessibility and UI consistency. [[1]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bL75-R93) [[2]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bL171-R207) [[3]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bR48-R52) [[4]](diffhunk://#diff-77ded9f0c7b7433876a4664662e16ed95f2074ae328a04a0a172624f2e4e610bL19-R22)
* The `RequestListItem` now passes `withName = true` and uses a larger container size for the profile section, ensuring the name and image fit well together. [[1]](diffhunk://#diff-6c761508d01ba07b5151649d165477fcbb31c7a9c26da397ec04907a132eabfeL196-R198) [[2]](diffhunk://#diff-77ded9f0c7b7433876a4664662e16ed95f2074ae328a04a0a172624f2e4e610bL19-R22)

**UI constants and layout adjustments:**

* Added `RequestItemNameFontSize` and `RequestItemCreatorSectionSize` to `ConstantRequestList`, and increased the profile icon size for better visibility and alignment.
* Updated imports and arrangement/layout logic in `ProfilePicture.kt` to support the new column structure and text display. [[1]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bR9-R20) [[2]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bR32-R36) [[3]](diffhunk://#diff-a2285e70bc5299f2807ee38bacdcf773c5037c08a0a96e8795fc2d6f34573d3bR153-R162)

**Testing improvements:**

* Added a new test `loadsProfileNameSuccessfully` to verify that the profile name is rendered when expected, utilizing the new `onAllNodesWithText` API for more robust assertions. [[1]](diffhunk://#diff-cfc693c9cff372a3e93f766404b09417200b88883cf83e21eebe553fbcf49de2R13) [[2]](diffhunk://#diff-cfc693c9cff372a3e93f766404b09417200b88883cf83e21eebe553fbcf49de2R711-R727)

These changes collectively improve the clarity and testability of profile information in the request list UI.