### PR TITLE
feat(validate-request): implement the vaidate-request screen

### DIFF
--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -54,7 +54,7 @@ sealed class Screen(
     }
   }
 
-  data class ValidateRequest(val requestId: String) : Screen("validateRequest/{requestId}") {
+  data class ValidateRequest(val requestId: String) : Screen(route = "validateRequest/$requestId") {
     companion object {
       const val ARG_REQUEST_ID = "requestId"
       const val route = "validateRequest/{$ARG_REQUEST_ID}"

--- a/app/src/main/java/com/android/sample/ui/overview/AcceptRequest.kt
+++ b/app/src/main/java/com/android/sample/ui/overview/AcceptRequest.kt
@@ -59,6 +59,7 @@ import java.util.Locale
 object AcceptRequestScreenTestTags {
   const val REQUEST_BUTTON = "requestButton"
   const val REQUEST_TITLE = "requestTitle"
+  const val VALIDATE_REQUEST_BUTTON = "validateRequestButton"
   const val REQUEST_DESCRIPTION = "requestDescription"
   const val REQUEST_TAG = "requestTag"
   const val REQUEST_TYPE = "requestType"
@@ -80,6 +81,7 @@ object AcceptRequestScreenTestTags {
 // Centralized user-visible strings for AcceptRequest screen
 object AcceptRequestScreenLabels {
   const val BACK = "Back"
+  const val VALIDATE_REQUEST = "Validate Request"
 
   const val DESCRIPTION = "Description"
   const val TAGS = "Tags"
@@ -111,6 +113,7 @@ object AcceptRequestScreenLabels {
 fun AcceptRequestScreen(
     requestId: String,
     acceptRequestViewModel: AcceptRequestViewModel = viewModel(),
+    onValidateClick: (String) -> Unit = {},
     onGoBack: () -> Unit = {},
     onEditClick: (String) -> Unit = {}
 ) {
@@ -264,6 +267,21 @@ fun AcceptRequestScreen(
                             style = MaterialTheme.typography.labelLarge)
                       }
                     }
+
+                if (isOwner) {
+                  Spacer(modifier = Modifier.height(AcceptRequestScreenConstants.SECTION_SPACING))
+
+                  FilledTonalButton(
+                      onClick = { onValidateClick(requestId) },
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .height(AcceptRequestScreenConstants.BUTTON_HEIGHT)
+                              .testTag(AcceptRequestScreenTestTags.VALIDATE_REQUEST_BUTTON)) {
+                        Text(
+                            text = AcceptRequestScreenLabels.VALIDATE_REQUEST,
+                            style = MaterialTheme.typography.labelLarge)
+                      }
+                }
 
                 // Volunteers expandable section (owners only)
                 if (isOwner) {

--- a/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestScreen.kt
@@ -1,0 +1,689 @@
+package com.android.sample.ui.request_validation
+
+import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.sample.model.profile.UserProfile
+import com.android.sample.model.profile.UserProfileRepository
+import com.android.sample.ui.profile.ProfilePicture
+
+/**
+ * Main screen for validating and closing a request. Allows the request creator to select helpers
+ * and award kudos.
+ *
+ * @param requestId The ID of the request to validate
+ * @param viewModel The ViewModel managing the validation state
+ * @param userProfileRepository Repository for loading user profiles (for ProfilePicture)
+ * @param onRequestClosed Callback invoked when request is successfully closed
+ * @param onNavigateBack Callback to navigate back
+ */
+@Composable
+fun ValidateRequestScreen(
+    requestId: String,
+    viewModel: ValidateRequestViewModel,
+    userProfileRepository: UserProfileRepository,
+    onRequestClosed: () -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  val state = viewModel.state
+
+  // Handle success navigation
+  LaunchedEffect(state) {
+    if (state is ValidationState.Success) {
+      onRequestClosed()
+    }
+  }
+
+  Scaffold(
+      modifier = modifier.fillMaxSize(),
+      topBar = {
+        ValidateRequestTopBar(
+            onNavigateBack = onNavigateBack, canNavigateBack = state !is ValidationState.Processing)
+      }) { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+          when (state) {
+            is ValidationState.Loading -> {
+              LoadingContent()
+            }
+            is ValidationState.Ready -> {
+              ReadyContent(
+                  request = state.request,
+                  helpers = state.helpers,
+                  selectedHelperIds = state.selectedHelperIds,
+                  userProfileRepository = userProfileRepository,
+                  onToggleHelper = { viewModel.toggleHelperSelection(it) },
+                  onValidate = { viewModel.showConfirmation() })
+            }
+            is ValidationState.Confirming -> {
+              // Keep ready content visible in background (for context)
+              // Note: We need to reconstruct a Ready state for background
+              // Alternatively, we can just show the dialog without background content
+              ConfirmationDialog(
+                  selectedHelpers = state.selectedHelpers,
+                  kudosToAward = state.kudosToAward,
+                  creatorBonus = state.creatorBonus,
+                  onConfirm = { viewModel.confirmAndClose() },
+                  onDismiss = { viewModel.cancelConfirmation() })
+            }
+            is ValidationState.Processing -> {
+              ProcessingContent()
+            }
+            is ValidationState.Error -> {
+              ErrorContent(
+                  message = state.message,
+                  canRetry = state.canRetry,
+                  onRetry = { viewModel.retry() },
+                  onBack = onNavigateBack)
+            }
+            is ValidationState.Success -> {
+              // This should trigger navigation via LaunchedEffect
+              SuccessContent()
+            }
+          }
+        }
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ValidateRequestTopBar(
+    onNavigateBack: () -> Unit,
+    canNavigateBack: Boolean,
+    modifier: Modifier = Modifier
+) {
+  TopAppBar(
+      title = {
+        Text(
+            text = ValidateRequestConstants.SCREEN_TITLE,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold)
+      },
+      navigationIcon = {
+        if (canNavigateBack) {
+          IconButton(
+              onClick = onNavigateBack,
+              modifier = Modifier.testTag(ValidateRequestConstants.TAG_BACK_BUTTON)) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = ValidateRequestConstants.CD_GO_BACK)
+              }
+        }
+      },
+      colors =
+          TopAppBarDefaults.topAppBarColors(
+              containerColor = MaterialTheme.colorScheme.surface,
+              titleContentColor = MaterialTheme.colorScheme.onSurface),
+      modifier = modifier)
+}
+
+@Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ValidateRequestConstants.SPACING_XLARGE_DP.dp)) {
+          CircularProgressIndicator(
+              modifier = Modifier.testTag(ValidateRequestConstants.TAG_LOADING_INDICATOR))
+          Text(
+              text = ValidateRequestConstants.LOADING_REQUEST,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ReadyContent(
+    request: com.android.sample.model.request.Request,
+    helpers: List<UserProfile>,
+    selectedHelperIds: Set<String>,
+    userProfileRepository: UserProfileRepository,
+    onToggleHelper: (String) -> Unit,
+    onValidate: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  Column(modifier = modifier.fillMaxSize().padding(ValidateRequestConstants.PADDING_SCREEN_DP.dp)) {
+    // Header section
+    Text(
+        text = ValidateRequestConstants.HEADER_SELECT_HELPERS,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = ValidateRequestConstants.SPACING_HEADER_BOTTOM_DP.dp))
+
+    Text(
+        text = ValidateRequestConstants.getHeaderDescription(request.title),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier =
+            Modifier.padding(bottom = ValidateRequestConstants.SPACING_DESCRIPTION_BOTTOM_DP.dp))
+
+    if (helpers.isEmpty()) {
+      // No helpers case
+      EmptyHelpersContent(onValidate = onValidate, modifier = Modifier.fillMaxSize())
+    } else {
+      // Helpers list
+      LazyColumn(
+          modifier = Modifier.weight(1f).testTag(ValidateRequestConstants.TAG_HELPERS_LIST),
+          verticalArrangement =
+              Arrangement.spacedBy(ValidateRequestConstants.SPACING_LARGE_DP.dp)) {
+            items(items = helpers, key = { it.id }) { helper ->
+              HelperCard(
+                  helper = helper,
+                  isSelected = helper.id in selectedHelperIds,
+                  userProfileRepository = userProfileRepository,
+                  onClick = { onToggleHelper(helper.id) },
+                  modifier = Modifier.animateItemPlacement())
+            }
+          }
+
+      Spacer(modifier = Modifier.height(ValidateRequestConstants.SPACING_XLARGE_DP.dp))
+
+      // Kudos summary
+      KudosSummary(
+          selectedCount = selectedHelperIds.size,
+          modifier =
+              Modifier.padding(vertical = ValidateRequestConstants.SPACING_SUMMARY_VERTICAL_DP.dp))
+
+      // Validate button
+      Button(
+          onClick = onValidate,
+          modifier =
+              Modifier.fillMaxWidth()
+                  .height(ValidateRequestConstants.BUTTON_HEIGHT_DP.dp)
+                  .testTag(ValidateRequestConstants.TAG_VALIDATE_BUTTON),
+          shape = RoundedCornerShape(ValidateRequestConstants.CORNER_RADIUS_MEDIUM_DP.dp),
+          colors =
+              ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)) {
+            Icon(
+                imageVector = Icons.Default.CheckCircle,
+                contentDescription = null,
+                modifier = Modifier.size(ValidateRequestConstants.BUTTON_ICON_SIZE_LARGE_DP.dp))
+            Spacer(modifier = Modifier.width(ValidateRequestConstants.SPACING_MEDIUM_DP.dp))
+            Text(
+                text = ValidateRequestConstants.BUTTON_VALIDATE,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold)
+          }
+    }
+  }
+}
+
+@Composable
+private fun EmptyHelpersContent(onValidate: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+      modifier = modifier,
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
+        Icon(
+            imageVector = Icons.Default.Info,
+            contentDescription = null,
+            modifier = Modifier.size(ValidateRequestConstants.LARGE_ICON_SIZE_DP.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant)
+
+        Spacer(modifier = Modifier.height(ValidateRequestConstants.SPACING_XLARGE_DP.dp))
+
+        Text(
+            text = ValidateRequestConstants.EMPTY_NO_HELPERS,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center)
+
+        Spacer(modifier = Modifier.height(ValidateRequestConstants.SPACING_MEDIUM_DP.dp))
+
+        Text(
+            text = ValidateRequestConstants.EMPTY_CAN_CLOSE,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier =
+                Modifier.padding(
+                    horizontal = ValidateRequestConstants.PADDING_HORIZONTAL_LARGE_DP.dp))
+
+        Spacer(modifier = Modifier.height(ValidateRequestConstants.SPACING_XXXLARGE_DP.dp))
+
+        Button(
+            onClick = onValidate,
+            modifier =
+                Modifier.fillMaxWidth(ValidateRequestConstants.WIDTH_FRACTION_EMPTY_BUTTON)
+                    .height(ValidateRequestConstants.BUTTON_HEIGHT_DP.dp)
+                    .testTag(ValidateRequestConstants.TAG_VALIDATE_BUTTON),
+            shape = RoundedCornerShape(ValidateRequestConstants.CORNER_RADIUS_MEDIUM_DP.dp)) {
+              Text(
+                  text = ValidateRequestConstants.BUTTON_CLOSE,
+                  style = MaterialTheme.typography.titleMedium)
+            }
+      }
+}
+
+@Composable
+private fun HelperCard(
+    helper: UserProfile,
+    isSelected: Boolean,
+    userProfileRepository: UserProfileRepository,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  val borderColor by
+      animateColorAsState(
+          targetValue =
+              if (isSelected) {
+                MaterialTheme.colorScheme.primary
+              } else {
+                MaterialTheme.colorScheme.outlineVariant
+              },
+          animationSpec = tween(ValidateRequestConstants.COLOR_ANIMATION_DURATION_MS),
+          label = "borderColor")
+  val backgroundColor by
+      animateColorAsState(
+          targetValue =
+              if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer.copy(
+                    alpha = ValidateRequestConstants.ALPHA_SELECTED_BACKGROUND)
+              } else {
+                MaterialTheme.colorScheme.surface
+              },
+          animationSpec = tween(ValidateRequestConstants.COLOR_ANIMATION_DURATION_MS),
+          label = "backgroundColor")
+
+  Card(
+      modifier =
+          modifier.fillMaxWidth().testTag(ValidateRequestConstants.getHelperCardTag(helper.id)),
+      shape = RoundedCornerShape(ValidateRequestConstants.CORNER_RADIUS_LARGE_DP.dp),
+      colors = CardDefaults.cardColors(containerColor = backgroundColor),
+      border =
+          BorderStroke(
+              width =
+                  if (isSelected) {
+                    ValidateRequestConstants.CARD_BORDER_WIDTH_SELECTED_DP.dp
+                  } else {
+                    ValidateRequestConstants.CARD_BORDER_WIDTH_UNSELECTED_DP.dp
+                  },
+              color = borderColor)) {
+        Row(
+            modifier =
+                Modifier.clickable(onClick = onClick)
+                    .padding(ValidateRequestConstants.PADDING_CARD_DP.dp)
+                    .fillMaxWidth(),
+            horizontalArrangement =
+                Arrangement.spacedBy(ValidateRequestConstants.SPACING_XLARGE_DP.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              // Profile picture section
+              Box(modifier = Modifier.size(ValidateRequestConstants.PROFILE_PICTURE_SIZE_DP.dp)) {
+                ProfilePicture(
+                    profileRepository = userProfileRepository,
+                    profileId = helper.id,
+                    onClick = { /* no-op, handled by parent */},
+                    modifier = Modifier.fillMaxSize())
+
+                // Selection indicator - using visibility instead of animation
+                if (isSelected) {
+                  Box(
+                      modifier =
+                          Modifier.align(Alignment.BottomEnd)
+                              .size(ValidateRequestConstants.SELECTION_INDICATOR_SIZE_DP.dp)
+                              .background(
+                                  color = MaterialTheme.colorScheme.primary, shape = CircleShape)
+                              .border(
+                                  width = ValidateRequestConstants.SELECTION_INDICATOR_BORDER_DP.dp,
+                                  color = MaterialTheme.colorScheme.surface,
+                                  shape = CircleShape),
+                      contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = ValidateRequestConstants.CD_SELECTED,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier =
+                                Modifier.size(
+                                    ValidateRequestConstants.SELECTION_INDICATOR_ICON_SIZE_DP.dp))
+                      }
+                }
+              }
+
+              // User info section
+              Column(
+                  modifier = Modifier.weight(1f),
+                  verticalArrangement =
+                      Arrangement.spacedBy(ValidateRequestConstants.SPACING_SMALL_DP.dp)) {
+                    Text(
+                        text = "${helper.name} ${helper.lastName}",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold)
+                    Text(
+                        text = ValidateRequestConstants.getUserKudos(helper.kudos),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                  }
+
+              // Kudos badge section - using Crossfade
+              Crossfade(targetState = isSelected) { selected ->
+                if (selected) {
+                  Surface(
+                      shape =
+                          RoundedCornerShape(ValidateRequestConstants.CORNER_RADIUS_SMALL_DP.dp),
+                      color = MaterialTheme.colorScheme.primary,
+                      modifier =
+                          Modifier.padding(
+                              start = ValidateRequestConstants.PADDING_BADGE_START_DP.dp)) {
+                        Row(
+                            modifier =
+                                Modifier.padding(
+                                    horizontal =
+                                        ValidateRequestConstants.PADDING_BADGE_HORIZONTAL_DP.dp,
+                                    vertical =
+                                        ValidateRequestConstants.PADDING_BADGE_VERTICAL_DP.dp),
+                            horizontalArrangement =
+                                Arrangement.spacedBy(ValidateRequestConstants.SPACING_SMALL_DP.dp),
+                            verticalAlignment = Alignment.CenterVertically) {
+                              Text(
+                                  text =
+                                      ValidateRequestConstants.getKudosBadge(
+                                          KudosConstants.KUDOS_PER_HELPER),
+                                  style = MaterialTheme.typography.labelLarge,
+                                  fontWeight = FontWeight.Bold,
+                                  color = MaterialTheme.colorScheme.onPrimary)
+                              Icon(
+                                  imageVector = Icons.Default.Star,
+                                  contentDescription = ValidateRequestConstants.CD_KUDOS,
+                                  tint = MaterialTheme.colorScheme.onPrimary,
+                                  modifier =
+                                      Modifier.size(ValidateRequestConstants.KUDOS_ICON_SIZE_DP.dp))
+                            }
+                      }
+                }
+              }
+            }
+      }
+}
+
+@Composable
+private fun KudosSummary(selectedCount: Int, modifier: Modifier = Modifier) {
+  val totalKudos = selectedCount * KudosConstants.KUDOS_PER_HELPER
+  val creatorBonus = if (selectedCount > 0) KudosConstants.KUDOS_FOR_CREATOR_RESOLUTION else 0
+
+  AnimatedVisibility(
+      visible = selectedCount > 0,
+      enter = fadeIn() + expandVertically(),
+      exit = fadeOut() + shrinkVertically(),
+      modifier = modifier) {
+        Card(
+            shape = RoundedCornerShape(ValidateRequestConstants.CORNER_RADIUS_MEDIUM_DP.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(ValidateRequestConstants.PADDING_CARD_DP.dp),
+                  horizontalArrangement = Arrangement.SpaceBetween,
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Column {
+                      Text(
+                          text = ValidateRequestConstants.SUMMARY_TOTAL_LABEL,
+                          style = MaterialTheme.typography.labelMedium,
+                          color = MaterialTheme.colorScheme.onSecondaryContainer)
+                      Text(
+                          text = ValidateRequestConstants.getSummaryHelperCount(selectedCount),
+                          style = MaterialTheme.typography.bodySmall,
+                          color =
+                              MaterialTheme.colorScheme.onSecondaryContainer.copy(
+                                  alpha = ValidateRequestConstants.ALPHA_SECONDARY_TEXT))
+                      if (creatorBonus > 0) {
+                        Text(
+                            text = ValidateRequestConstants.getSummaryCreatorBonus(creatorBonus),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Medium)
+                      }
+                    }
+
+                    Row(
+                        horizontalArrangement =
+                            Arrangement.spacedBy(ValidateRequestConstants.SPACING_SMALL_DP.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                          Text(
+                              text = "$totalKudos",
+                              style = MaterialTheme.typography.headlineMedium,
+                              fontWeight = FontWeight.Bold,
+                              color = MaterialTheme.colorScheme.onSecondaryContainer)
+                          Icon(
+                              imageVector = Icons.Default.Star,
+                              contentDescription = ValidateRequestConstants.CD_KUDOS,
+                              tint = MaterialTheme.colorScheme.primary,
+                              modifier =
+                                  Modifier.size(
+                                      ValidateRequestConstants.KUDOS_ICON_LARGE_SIZE_DP.dp))
+                        }
+                  }
+            }
+      }
+}
+
+@Composable
+private fun ConfirmationDialog(
+    selectedHelpers: List<UserProfile>,
+    kudosToAward: Int,
+    creatorBonus: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      title = { Text(text = ValidateRequestConstants.CONFIRM_TITLE, fontWeight = FontWeight.Bold) },
+      text = {
+        Column(
+            verticalArrangement =
+                Arrangement.spacedBy(ValidateRequestConstants.SPACING_LARGE_DP.dp)) {
+              if (selectedHelpers.isEmpty()) {
+                Text(ValidateRequestConstants.CONFIRM_NO_HELPERS)
+                Text(
+                    text = ValidateRequestConstants.CONFIRM_NO_KUDOS,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error)
+              } else {
+                Text(ValidateRequestConstants.CONFIRM_AWARD_TO)
+
+                selectedHelpers.forEach { helper ->
+                  Row(
+                      horizontalArrangement =
+                          Arrangement.spacedBy(ValidateRequestConstants.SPACING_MEDIUM_DP.dp),
+                      verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.CheckCircle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier =
+                                Modifier.size(ValidateRequestConstants.DIALOG_ICON_SIZE_DP.dp))
+                        Text(
+                            text = "${helper.name} ${helper.lastName}",
+                            style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            text =
+                                "(${ValidateRequestConstants.getKudosBadge(KudosConstants.KUDOS_PER_HELPER)})",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Bold)
+                      }
+                }
+
+                HorizontalDivider(
+                    modifier =
+                        Modifier.padding(
+                            vertical = ValidateRequestConstants.PADDING_VERTICAL_DIALOG_DP.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween) {
+                      Text(
+                          text = ValidateRequestConstants.CONFIRM_TOTAL_KUDOS,
+                          style = MaterialTheme.typography.titleMedium,
+                          fontWeight = FontWeight.Bold)
+                      Text(
+                          text = "$kudosToAward",
+                          style = MaterialTheme.typography.titleMedium,
+                          fontWeight = FontWeight.Bold,
+                          color = MaterialTheme.colorScheme.primary)
+                    }
+
+                if (creatorBonus > 0) {
+                  Text(
+                      text = ValidateRequestConstants.getConfirmCreatorBonus(creatorBonus),
+                      style = MaterialTheme.typography.bodySmall,
+                      color = MaterialTheme.colorScheme.tertiary,
+                      fontWeight = FontWeight.Medium)
+                }
+              }
+
+              Text(
+                  text = ValidateRequestConstants.CONFIRM_CANNOT_UNDO,
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.error,
+                  fontWeight = FontWeight.Medium)
+            }
+      },
+      confirmButton = {
+        Button(
+            onClick = onConfirm,
+            modifier = Modifier.testTag(ValidateRequestConstants.TAG_CONFIRM_BUTTON)) {
+              Text(ValidateRequestConstants.BUTTON_CONFIRM)
+            }
+      },
+      dismissButton = {
+        TextButton(
+            onClick = onDismiss,
+            modifier = Modifier.testTag(ValidateRequestConstants.TAG_CANCEL_BUTTON)) {
+              Text(ValidateRequestConstants.BUTTON_CANCEL)
+            }
+      },
+      modifier = modifier.testTag(ValidateRequestConstants.TAG_CONFIRMATION_DIALOG))
+}
+
+@Composable
+private fun ProcessingContent(modifier: Modifier = Modifier) {
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ValidateRequestConstants.SPACING_XLARGE_DP.dp)) {
+          CircularProgressIndicator(
+              modifier = Modifier.testTag(ValidateRequestConstants.TAG_PROCESSING_INDICATOR))
+          Text(
+              text = ValidateRequestConstants.PROCESSING_REQUEST,
+              style = MaterialTheme.typography.bodyLarge,
+              textAlign = TextAlign.Center,
+              color = MaterialTheme.colorScheme.onSurfaceVariant)
+          Text(
+              text = ValidateRequestConstants.PROCESSING_WAIT,
+              style = MaterialTheme.typography.bodyMedium,
+              color =
+                  MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                      alpha = ValidateRequestConstants.ALPHA_SECONDARY_TEXT))
+        }
+  }
+}
+
+@Composable
+private fun SuccessContent(modifier: Modifier = Modifier) {
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ValidateRequestConstants.SPACING_XLARGE_DP.dp)) {
+          Icon(
+              imageVector = Icons.Default.CheckCircle,
+              contentDescription = ValidateRequestConstants.CD_SUCCESS,
+              tint = MaterialTheme.colorScheme.primary,
+              modifier = Modifier.size(ValidateRequestConstants.LARGE_ICON_SIZE_DP.dp))
+          Text(
+              text = ValidateRequestConstants.SUCCESS_TITLE,
+              style = MaterialTheme.typography.titleLarge,
+              fontWeight = FontWeight.Bold,
+              textAlign = TextAlign.Center)
+          Text(
+              text = ValidateRequestConstants.SUCCESS_SUBTITLE,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              textAlign = TextAlign.Center)
+        }
+  }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    canRetry: Boolean,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ValidateRequestConstants.SPACING_XLARGE_DP.dp),
+        modifier = Modifier.padding(ValidateRequestConstants.PADDING_HORIZONTAL_LARGE_DP.dp)) {
+          Icon(
+              imageVector = Icons.Default.Warning,
+              contentDescription = ValidateRequestConstants.CD_ERROR,
+              tint = MaterialTheme.colorScheme.error,
+              modifier = Modifier.size(ValidateRequestConstants.LARGE_ICON_SIZE_DP.dp))
+
+          Text(
+              text = ValidateRequestConstants.ERROR_TITLE,
+              style = MaterialTheme.typography.titleLarge,
+              fontWeight = FontWeight.Bold,
+              color = MaterialTheme.colorScheme.error)
+
+          Text(
+              text = message,
+              style = MaterialTheme.typography.bodyLarge,
+              textAlign = TextAlign.Center,
+              color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+          Row(
+              horizontalArrangement =
+                  Arrangement.spacedBy(ValidateRequestConstants.SPACING_LARGE_DP.dp),
+              modifier = Modifier.padding(top = ValidateRequestConstants.SPACING_ERROR_TOP_DP.dp)) {
+                if (canRetry) {
+                  Button(
+                      onClick = onRetry,
+                      modifier = Modifier.testTag(ValidateRequestConstants.TAG_RETRY_BUTTON)) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = null,
+                            modifier =
+                                Modifier.size(ValidateRequestConstants.BUTTON_ICON_SIZE_DP.dp))
+                        Spacer(
+                            modifier =
+                                Modifier.width(ValidateRequestConstants.SPACING_MEDIUM_DP.dp))
+                        Text(ValidateRequestConstants.BUTTON_RETRY)
+                      }
+                }
+
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier.testTag(ValidateRequestConstants.TAG_BACK_BUTTON)) {
+                      Text(ValidateRequestConstants.BUTTON_GO_BACK)
+                    }
+              }
+        }
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestViewModel.kt
@@ -94,16 +94,23 @@ class ValidateRequestViewModel(
       state = ValidationState.Loading
 
       try {
+        android.util.Log.d(VALIDATE_REQUEST, "Loading request with ID: $requestId")
         val request = requestRepository.getRequest(requestId)
+        android.util.Log.d(
+            VALIDATE_REQUEST,
+            "Request loaded successfully: ${request.requestId}, owner: ${request.creatorId}")
 
         // Extract validation to separate method
         validateRequestForClosure(request)?.let { errorState ->
+          android.util.Log.e(VALIDATE_REQUEST, "Validation failed: ${errorState.message}")
+
           state = errorState
           return@launch
         }
 
         // Extract helper loading to separate method
         val helpers = loadHelperProfiles(request.people)
+        android.util.Log.d(VALIDATE_REQUEST, "Loaded ${helpers.size} helpers")
 
         // Validate helpers loaded successfully
         if (helpers.isEmpty() && request.people.isNotEmpty()) {
@@ -115,6 +122,8 @@ class ValidateRequestViewModel(
             ValidationState.Ready(
                 request = request, helpers = helpers, selectedHelperIds = emptySet())
       } catch (e: Exception) {
+        android.util.Log.e(VALIDATE_REQUEST, "Exception loading request", e)
+
         state =
             ValidationState.Error(
                 message = "$FAILED_TO_LOAD_REQUESTS ${e.message}", canRetry = true)

--- a/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestsConstants.kt
+++ b/app/src/main/java/com/android/sample/ui/request_validation/ValidateRequestsConstants.kt
@@ -1,0 +1,160 @@
+package com.android.sample.ui.request_validation
+
+/**
+ * UI constants and strings for the request validation screen. Centralized for easy maintenance and
+ * potential i18n support.
+ *
+ * ALL magic values are defined here - no hardcoded values in the UI code.
+ */
+object ValidateRequestConstants {
+
+  // ==================== STRINGS ====================
+
+  // Screen titles and headers
+  const val SCREEN_TITLE = "Resolve Request"
+  const val HEADER_SELECT_HELPERS = "Select helpers to reward"
+
+  // Instructions and descriptions
+  fun getHeaderDescription(requestTitle: String) =
+      "Choose the people who helped you with \"$requestTitle\""
+
+  // Loading states
+  const val LOADING_REQUEST = "Loading request details..."
+  const val PROCESSING_REQUEST = "Closing request and awarding kudos..."
+  const val PROCESSING_WAIT = "Please wait"
+
+  // Success messages
+  const val SUCCESS_TITLE = "Request closed successfully!"
+  const val SUCCESS_SUBTITLE = "Kudos have been awarded"
+
+  // Error messages
+  const val ERROR_TITLE = "Error"
+  const val ERROR_NOT_OWNER = "You are not the owner of this request."
+  const val ERROR_INVALID_STATUS = "This request cannot be closed. Status: "
+  const val ERROR_LOAD_PROFILES = "Could not load helper profiles. Please try again."
+  const val ERROR_LOAD_REQUEST_PREFIX = "Failed to load request: "
+  const val ERROR_CLOSE_REQUEST_PREFIX = "Failed to close request: "
+  const val ERROR_AWARD_KUDOS_PREFIX = "Failed to award kudos: "
+  const val ERROR_UNEXPECTED_PREFIX = "An unexpected error occurred: "
+
+  // Empty state
+  const val EMPTY_NO_HELPERS = "No one has accepted this request yet"
+  const val EMPTY_CAN_CLOSE = "You can still close the request without awarding kudos"
+
+  // Buttons
+  const val BUTTON_VALIDATE = "Close Request & Award Kudos"
+  const val BUTTON_CLOSE = "Close Request"
+  const val BUTTON_CONFIRM = "Confirm & Close"
+  const val BUTTON_CANCEL = "Cancel"
+  const val BUTTON_RETRY = "Retry"
+  const val BUTTON_GO_BACK = "Go Back"
+
+  // Confirmation dialog
+  const val CONFIRM_TITLE = "Confirm & Close Request"
+  const val CONFIRM_NO_HELPERS =
+      "You are about to close this request without selecting any helpers."
+  const val CONFIRM_NO_KUDOS = "No kudos will be awarded."
+  const val CONFIRM_AWARD_TO = "You are about to award kudos to:"
+  const val CONFIRM_TOTAL_KUDOS = "Total kudos:"
+  const val CONFIRM_CANNOT_UNDO = "This action cannot be undone."
+
+  // Symbols and formatting
+  const val SYMBOL_MULTIPLY = " × "
+  const val SYMBOL_PLUS = "+"
+
+  fun getConfirmCreatorBonus(kudos: Int) =
+      "You will receive ${SYMBOL_PLUS}$kudos kudos for resolving this request!"
+
+  // Kudos summary
+  const val SUMMARY_TOTAL_LABEL = "Total kudos to award"
+
+  fun getSummaryHelperCount(count: Int) =
+      "$count helper${if (count != 1) "s" else ""}$SYMBOL_MULTIPLY${KudosConstants.KUDOS_PER_HELPER} kudos"
+
+  fun getSummaryCreatorBonus(kudos: Int) = "You will receive ${SYMBOL_PLUS}$kudos kudos"
+
+  // Profile display
+  const val KUDOS_SUFFIX = " kudos"
+
+  fun getUserKudos(kudos: Int) = "$kudos$KUDOS_SUFFIX"
+
+  fun getKudosBadge(kudos: Int) = "$SYMBOL_PLUS$kudos"
+
+  // Content descriptions (accessibility)
+  const val CD_GO_BACK = "Go back"
+  const val CD_PROFILE_PICTURE = "Profile picture of "
+  const val CD_SELECTED = "Selected"
+  const val CD_KUDOS = "Kudos"
+  const val CD_SUCCESS = "Success"
+  const val CD_ERROR = "Error"
+
+  // ==================== TEST TAGS ====================
+
+  const val TAG_BACK_BUTTON = "backButton"
+  const val TAG_LOADING_INDICATOR = "loadingIndicator"
+  const val TAG_HELPERS_LIST = "helpersList"
+  const val TAG_VALIDATE_BUTTON = "validateButton"
+  const val TAG_PROCESSING_INDICATOR = "processingIndicator"
+  const val TAG_CONFIRMATION_DIALOG = "confirmationDialog"
+  const val TAG_CONFIRM_BUTTON = "confirmButton"
+  const val TAG_CANCEL_BUTTON = "cancelButton"
+  const val TAG_RETRY_BUTTON = "retryButton"
+
+  fun getHelperCardTag(userId: String) = "helperCard_$userId"
+
+  // ==================== DIMENSIONS (DP) ====================
+
+  // Icon sizes
+  const val PROFILE_PICTURE_SIZE_DP = 56
+  const val SELECTION_INDICATOR_SIZE_DP = 20
+  const val SELECTION_INDICATOR_ICON_SIZE_DP = 12
+  const val KUDOS_ICON_SIZE_DP = 16
+  const val KUDOS_ICON_LARGE_SIZE_DP = 32
+  const val LARGE_ICON_SIZE_DP = 64
+  const val BUTTON_ICON_SIZE_DP = 20
+  const val BUTTON_ICON_SIZE_LARGE_DP = 24
+  const val DIALOG_ICON_SIZE_DP = 16
+
+  // Component sizes
+  const val BUTTON_HEIGHT_DP = 56
+  const val SELECTION_INDICATOR_BORDER_DP = 2
+  const val CARD_BORDER_WIDTH_UNSELECTED_DP = 1
+  const val CARD_BORDER_WIDTH_SELECTED_DP = 2
+  const val PROFILE_BORDER_WIDTH_DP = 2
+
+  // Padding and spacing
+  const val PADDING_SCREEN_DP = 16
+  const val PADDING_CARD_DP = 16
+  const val PADDING_BADGE_HORIZONTAL_DP = 12
+  const val PADDING_BADGE_VERTICAL_DP = 6
+  const val PADDING_BADGE_START_DP = 8
+  const val PADDING_HORIZONTAL_LARGE_DP = 32
+  const val PADDING_VERTICAL_DIALOG_DP = 8
+
+  const val SPACING_SMALL_DP = 4
+  const val SPACING_MEDIUM_DP = 8
+  const val SPACING_LARGE_DP = 12
+  const val SPACING_XLARGE_DP = 16
+  const val SPACING_XXLARGE_DP = 24
+  const val SPACING_XXXLARGE_DP = 32
+
+  const val SPACING_HEADER_BOTTOM_DP = 8
+  const val SPACING_DESCRIPTION_BOTTOM_DP = 24
+  const val SPACING_SUMMARY_VERTICAL_DP = 8
+  const val SPACING_ERROR_TOP_DP = 16
+
+  // Corner radius
+  const val CORNER_RADIUS_SMALL_DP = 8
+  const val CORNER_RADIUS_MEDIUM_DP = 12
+  const val CORNER_RADIUS_LARGE_DP = 16
+
+  // ==================== FRACTIONS & RATIOS ====================
+
+  const val ALPHA_SELECTED_BACKGROUND = 0.3f
+  const val ALPHA_SECONDARY_TEXT = 0.7f
+  const val WIDTH_FRACTION_EMPTY_BUTTON = 0.7f
+
+  // ==================== ANIMATION ====================
+
+  const val COLOR_ANIMATION_DURATION_MS = 200
+}


### PR DESCRIPTION
## Dynamic Request List Filtering

### Summary
Implemented filtering in the request list to only display active requests (OPEN and IN_PROGRESS status), hiding completed, cancelled, and expired requests from users.
## Issue
- addresses issue #179 
### Changes Made

#### `Request.kt`
- **Fixed `viewStatus` logic** to respect manually set `COMPLETED` status
- Previously, `viewStatus` would override manually completed requests based on time
- Now properly returns `COMPLETED` when `status == RequestStatus.COMPLETED`

#### `RequestListViewModel.kt`
- **Added filtering in `loadRequests()`** to show only active requests
- Filters requests where `viewStatus == OPEN || viewStatus == IN_PROGRESS`
- Added `refreshRequests()` method to reload the request list
- Completed, cancelled, archived, and expired requests are now hidden from the list

#### `NavigationScreen.kt`
- Added `UserProfileRepositoryFirestore` initialization for profile operations

### Behavior
- Users now see only actionable requests (OPEN or IN_PROGRESS)
- When a request is closed/completed, it automatically disappears from the list
- Request list refreshes properly when returning from other screens

### Testing
- Added tests to verify completed requests are filtered out
- Added tests to verify expired requests are filtered out  
- Added tests to verify cancelled requests are filtered out
- Existing tests updated to work with new filtering logic

### Breaking Changes
None - this is an enhancement to improve UX by reducing clutter in the request list.