### PR TITLE
feat(request): update request list dynamically

### DIFF
--- a/app/src/main/java/com/android/sample/model/request/Request.kt
+++ b/app/src/main/java/com/android/sample/model/request/Request.kt
@@ -27,8 +27,9 @@ data class Request(
       val now = Date()
 
       return when {
-        status == RequestStatus.CANCELLED || status == RequestStatus.ARCHIVED -> status
-
+        status == RequestStatus.COMPLETED ||
+            status == RequestStatus.CANCELLED ||
+            status == RequestStatus.ARCHIVED -> status
         // COMPLETED when expirationTime <= now
         !expirationTime.after(now) -> RequestStatus.COMPLETED
 


### PR DESCRIPTION
## Dynamic Request List Filtering

### Summary
Implemented filtering in the request list to only display active requests (OPEN and IN_PROGRESS status), hiding completed, cancelled, and expired requests from users.
## Issue
- addresses issue #179 
### Changes Made

#### `Request.kt`
- **Fixed `viewStatus` logic** to respect manually set `COMPLETED` status
- Previously, `viewStatus` would override manually completed requests based on time
- Now properly returns `COMPLETED` when `status == RequestStatus.COMPLETED`

#### `RequestListViewModel.kt`
- **Added filtering in `loadRequests()`** to show only active requests
- Filters requests where `viewStatus == OPEN || viewStatus == IN_PROGRESS`
- Added `refreshRequests()` method to reload the request list
- Completed, cancelled, archived, and expired requests are now hidden from the list

#### `NavigationScreen.kt`
- Added `UserProfileRepositoryFirestore` initialization for profile operations

### Behavior
- Users now see only actionable requests (OPEN or IN_PROGRESS)
- When a request is closed/completed, it automatically disappears from the list
- Request list refreshes properly when returning from other screens

### Testing
- Added tests to verify completed requests are filtered out
- Added tests to verify expired requests are filtered out  
- Added tests to verify cancelled requests are filtered out
- Existing tests updated to work with new filtering logic

### Breaking Changes
None - this is an enhancement to improve UX by reducing clutter in the request list.