### PR TITLE
fix(TypeChip): improve text auto-sizing and prevent overflow

### DIFF
--- a/app/src/main/java/com/android/sample/ui/request/ConstantRequestList.kt
+++ b/app/src/main/java/com/android/sample/ui/request/ConstantRequestList.kt
@@ -28,6 +28,8 @@ object ConstantRequestList {
   val RequestItemProfileHeightPadding = 5.dp
   val TypeChipTextPadding = 4.dp
   val TypeChipTextSize = 12.sp
+  val TypeChipTextSizeFactor = 0.6f // used for text auto-sizing inside chip
+  val TypeChipCornerRadius = 16.dp
   val TypeChipBorderWidth = 0.5.dp
   val TypeChipColumnSpacing = 3.dp
 

--- a/app/src/main/java/com/android/sample/ui/request/RequestList.kt
+++ b/app/src/main/java/com/android/sample/ui/request/RequestList.kt
@@ -1,5 +1,6 @@
 package com.android.sample.ui.request
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -13,6 +14,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -32,7 +34,10 @@ import com.android.sample.ui.navigation.Screen
 import com.android.sample.ui.profile.ProfilePicture
 import com.android.sample.ui.request.ConstantRequestList.TypeChipBorderWidth
 import com.android.sample.ui.request.ConstantRequestList.TypeChipColumnSpacing
+import com.android.sample.ui.request.ConstantRequestList.TypeChipCornerRadius
 import com.android.sample.ui.request.ConstantRequestList.TypeChipTextPadding
+import com.android.sample.ui.request.ConstantRequestList.TypeChipTextSize
+import com.android.sample.ui.request.ConstantRequestList.TypeChipTextSizeFactor
 import com.android.sample.ui.theme.TopNavigationBar
 import com.android.sample.ui.theme.appPalette
 
@@ -311,6 +316,7 @@ fun TitleAndDescription(request: Request, modifier: Modifier = Modifier) {
   }
 }
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun TypeChip(
     requestType: RequestType,
@@ -318,18 +324,31 @@ fun TypeChip(
 ) {
   Surface(
       color = appPalette().getRequestTypeBackgroundColor(requestType),
-      shape = RoundedCornerShape(16.dp),
-      modifier = modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(TypeChipCornerRadius),
+      modifier = modifier.fillMaxWidth(), // Fill the available width
       border = BorderStroke(TypeChipBorderWidth, appPalette().getRequestTypeColor(requestType))) {
-        Box(
+        BoxWithConstraints(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxHeight().padding(horizontal = TypeChipTextPadding)) {
+            modifier = Modifier.padding(horizontal = TypeChipTextPadding)) {
+              val baseFontSize = TypeChipTextSize
+              val textLength = requestType.displayString().length
+
+              val density = LocalDensity.current
+              val availableWidthPx = with(density) { maxWidth.toPx() }
+
+              val baseFontSizePx = with(density) { baseFontSize.toPx() }
+
+              val estimatedTextWidth = textLength * baseFontSizePx * TypeChipTextSizeFactor
+              val scaleFactor = (availableWidthPx / estimatedTextWidth).coerceAtMost(1.0f)
+
               Text(
                   text = requestType.displayString(),
                   color = appPalette().getRequestTypeColor(requestType),
-                  fontSize = 12.sp,
+                  fontSize = baseFontSize * scaleFactor,
                   fontWeight = FontWeight.Medium,
-                  maxLines = 1)
+                  maxLines = 1,
+                  overflow = TextOverflow.Clip // Prevent ellipsis from showing up unnecessarily
+                  )
             }
       }
 }


### PR DESCRIPTION
This pull request enhances the appearance and usability of the request type chips in the UI by introducing dynamic text sizing and improving the visual styling. The most important changes focus on making the chip text auto-size to fit the available space and centralizing style constants.

**UI/UX improvements for request type chips:**

* Refactored the `TypeChip` composable to use `BoxWithConstraints` and dynamically scale the text size based on the chip's available width, ensuring that longer request type names fit without overflowing or ellipsis.
* Added `TypeChipTextSizeFactor` and `TypeChipCornerRadius` constants to `ConstantRequestList` to support dynamic text sizing and consistent corner styling.
* Updated the chip's shape to use the new `TypeChipCornerRadius` constant for consistent rounded corners.

**Code organization and imports:**

* Imported `LocalDensity` and related constants into `RequestList.kt` to support text auto-sizing logic and maintain code clarity. [[1]](diffhunk://#diff-6c761508d01ba07b5151649d165477fcbb31c7a9c26da397ec04907a132eabfeR17) [[2]](diffhunk://#diff-6c761508d01ba07b5151649d165477fcbb31c7a9c26da397ec04907a132eabfeR37-R40)

**Photo**
<img width="1005" height="262" alt="image" src="https://github.com/user-attachments/assets/725e2163-f2d8-451b-9f05-0bc6bf5d908a" />
