### PR TITLE
feat(profile): implement profile caching and offline mode handling

### DIFF
--- a/app/src/main/java/com/android/sample/ui/navigation/NavigationScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavigationScreen.kt
@@ -98,7 +98,10 @@ fun NavigationScreen(
   val requestListViewModel: RequestListViewModel =
       viewModel(
           factory =
-              RequestListViewModelFactory(showOnlyMyRequests = false, requestCache = requestCache))
+              RequestListViewModelFactory(
+                  showOnlyMyRequests = false,
+                  requestCache = requestCache,
+                  profileCache = profileCache))
   val editRequestViewModel: EditRequestViewModel =
       viewModel(
           factory =
@@ -237,7 +240,8 @@ fun NavigationScreen(
         val userId = navBackStackEntry.arguments?.getString(Screen.PublicProfile.ARG_USER_ID)
         userId?.let { id ->
           val publicProfileViewModel: PublicProfileViewModel =
-              viewModel(factory = PublicProfileViewModelFactory(userProfileRepository))
+              viewModel(
+                  factory = PublicProfileViewModelFactory(userProfileRepository, profileCache))
           PublicProfileScreen(
               viewModel = publicProfileViewModel,
               defaultProfileId = id,

--- a/app/src/main/java/com/android/sample/ui/profile/ProfilePicture.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfilePicture.kt
@@ -110,8 +110,6 @@ fun ProfilePicture(
               ProfileCache.put(profileId, p)
               p
             } catch (e: Exception) {
-              // couldn't fetch profile
-              ProfileCache.put(profileId, null)
               null
             }
 

--- a/app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileScreen.kt
@@ -28,9 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.model.profile.UserProfile
+import com.android.sample.ui.profile.PROFILE_OFFLINE_TEXT
 import com.android.sample.ui.profile.ProfileDimens
 import com.android.sample.ui.profile.ProfilePicture
 import com.android.sample.ui.profile.ProfileState
@@ -95,12 +97,20 @@ fun PublicProfileScreen(
                     ErrorBanner(it)
                     Spacer(modifier = Modifier.height(ProfileDimens.Vertical))
                   }
+                  if (shownState.offlineMode) {
+                    Text(
+                        PROFILE_OFFLINE_TEXT,
+                        color = appPalette().error,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth())
+                  }
 
                   PublicProfileHeader(
                       profile = shownState.profile,
                       isFollowing = isFollowing,
                       onFollowToggle = { isFollowing = !isFollowing },
-                      modifier = Modifier.testTag(PublicProfileTestTags.PUBLIC_PROFILE_HEADER))
+                      modifier = Modifier.testTag(PublicProfileTestTags.PUBLIC_PROFILE_HEADER),
+                      uiState = shownState)
                   Spacer(modifier = Modifier.height(ProfileDimens.Horizontal))
                   ProfileStats(state = profileState)
                   Spacer(modifier = Modifier.height(ProfileDimens.Horizontal))
@@ -119,7 +129,8 @@ fun PublicProfileHeader(
     isFollowing: Boolean,
     onFollowToggle: () -> Unit,
     modifier: Modifier = Modifier,
-    palette: AppPalette = appPalette()
+    palette: AppPalette = appPalette(),
+    uiState: PublicProfileUiState
 ) {
   val accent = palette.accent
   val textColor = AppColors.WhiteColor
@@ -179,7 +190,9 @@ fun PublicProfileHeader(
                   modifier = Modifier.testTag(PublicProfileTestTags.PUBLIC_PROFILE_HEADER_EMAIL))
             }
             Spacer(modifier = Modifier.weight(1f))
-            FollowButton(isFollowing = isFollowing, onToggle = onFollowToggle)
+            if (!uiState.offlineMode) {
+              FollowButton(isFollowing = isFollowing, onToggle = onFollowToggle)
+            }
           }
         }
       }


### PR DESCRIPTION
This pull request adds offline mode support to the public profile feature and improves caching of user profiles for better resilience and performance. The main changes include passing a `UserProfileCache` to relevant view models and factories, updating UI components to indicate offline mode, and saving user profiles to cache when loading requests.

**Offline mode and profile caching improvements:**

* Added offline mode support to `PublicProfileViewModel` and `PublicProfileUiState`, allowing the app to display cached profiles and show an offline indicator if network requests fail. The UI now conditionally shows the follow button and offline text based on connectivity. (`app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileViewModel.kt`, `app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileScreen.kt`) [[1]](diffhunk://#diff-9d793964bcdb4a8c328fc400ed0559f6ac12d65fc8226471f14c3658db451c9eL16-R24) [[2]](diffhunk://#diff-9d793964bcdb4a8c328fc400ed0559f6ac12d65fc8226471f14c3658db451c9eL38-R58) [[3]](diffhunk://#diff-20770e9a7f5e859318998f696603840546eab36ead2307d254007ab3b0aa323dR100-R113) [[4]](diffhunk://#diff-20770e9a7f5e859318998f696603840546eab36ead2307d254007ab3b0aa323dL122-R133) [[5]](diffhunk://#diff-20770e9a7f5e859318998f696603840546eab36ead2307d254007ab3b0aa323dR193-R199)
* Updated `PublicProfileViewModelFactory` and `NavigationScreen` to accept and pass the `profileCache` dependency, ensuring cached profiles are available throughout the navigation and profile flows. (`app/src/main/java/com/android/sample/ui/navigation/NavigationScreen.kt`, `app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileViewModel.kt`) [[1]](diffhunk://#diff-558cb610bcac4a2f39e4303baf6f659fa1dd50c16b03ab5d417dc57feab6b8efL240-R244) [[2]](diffhunk://#diff-9d793964bcdb4a8c328fc400ed0559f6ac12d65fc8226471f14c3658db451c9eL60-R80) [[3]](diffhunk://#diff-558cb610bcac4a2f39e4303baf6f659fa1dd50c16b03ab5d417dc57feab6b8efL101-R104)
* Modified `RequestListViewModel` and its factory to include a `profileCache` parameter and added logic to save user profiles to cache when loading requests, improving offline capabilities and reducing redundant network calls. (`app/src/main/java/com/android/sample/ui/request/RequestListViewModel.kt`) [[1]](diffhunk://#diff-db63de506e2f35b6cc6e6d397cb8f3b81266a8192f9e8fba3686eb74b8e74a03L39-R41) [[2]](diffhunk://#diff-db63de506e2f35b6cc6e6d397cb8f3b81266a8192f9e8fba3686eb74b8e74a03R135-R165) [[3]](diffhunk://#diff-db63de506e2f35b6cc6e6d397cb8f3b81266a8192f9e8fba3686eb74b8e74a03R66)
* Minor UI and import updates to support the new offline mode indicator and ensure proper text alignment and error messaging in the public profile screen. (`app/src/main/java/com/android/sample/ui/profile/publicProfile/PublicProfileScreen.kt`)
* Removed redundant cache writes for failed profile fetches in `ProfilePicture`, as offline mode now handles profile caching more robustly. (`app/src/main/java/com/android/sample/ui/profile/ProfilePicture.kt`)