### PR TITLE
fix(location-search): make dropdown menu non-focusable

### DIFF
--- a/app/src/main/java/com/android/sample/ui/request/LocationSearchField.kt
+++ b/app/src/main/java/com/android/sample/ui/request/LocationSearchField.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.window.PopupProperties
 import com.android.sample.R
 import com.android.sample.model.map.EMPTY_LOCATION
 import com.android.sample.model.map.Location
@@ -125,6 +126,7 @@ fun LocationSearchField(
 
       // Dropdown menu for search results
       DropdownMenu(
+          properties = PopupProperties(focusable = false),
           expanded = showDropdown && searchResults.isNotEmpty(),
           onDismissRequest = { showDropdown = false },
           modifier =


### PR DESCRIPTION
This pull request makes a minor update to the `LocationSearchField` composable to improve the behavior of its dropdown menu. The main change is the addition of a property to the dropdown menu to prevent it from capturing focus.

* UI Behavior:
  * In `LocationSearchField`, the dropdown menu now uses `PopupProperties(focusable = false)` to ensure it does not take focus away from other UI elements. [[1]](diffhunk://#diff-9615477c20bbdaa685e11a126aab9dac138dbbf94c2ab3c45d29c385b37615d5R14) [[2]](diffhunk://#diff-9615477c20bbdaa685e11a126aab9dac138dbbf94c2ab3c45d29c385b37615d5R129)