### PR TITLE
fix(authentification): remove tint on app logo

### DIFF
--- a/app/src/main/java/com/android/sample/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignInScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -130,8 +129,7 @@ fun SignInScreen(
         Image(
             painter = painterResource(R.drawable.campusreach_logo),
             contentDescription = "App Logo",
-            modifier = Modifier.size(UiDimens.IconLarge).testTag(SignInScreenTestTags.APP_LOGO),
-            colorFilter = ColorFilter.tint(appPalette().accent))
+            modifier = Modifier.size(UiDimens.IconLarge).testTag(SignInScreenTestTags.APP_LOGO))
 
         // Welcome title
         Text(


### PR DESCRIPTION
# Fix the disappearing app logo on the sign in screen

- #389

It was being tinted and therefore replaced by a blue circle. I removed that, so now it's back.

<img width="426" height="947" alt="image" src="https://github.com/user-attachments/assets/1347822e-7136-437e-99c3-bbcb1a0de9e1" />
